### PR TITLE
Fix build-native to add default GNU assembler

### DIFF
--- a/client/icecc-create-env
+++ b/client/icecc-create-env
@@ -166,7 +166,12 @@ if test -n "$gcc"; then
       add_file "$specfile"
     fi
 
-    add_file $($added_gcc -print-prog-name=as) /usr/bin/as
+    gcc_as=$($added_gcc -print-prog-name=as)
+    if test "$gcc_as" = "as"; then
+      add_file /usr/bin/as
+    else
+      add_file "$gcc_as" /usr/bin/as
+    fi
 
     plugin_name=liblto_plugin.so
     plugin=`$added_gcc -print-prog-name=$plugin_name`


### PR DESCRIPTION
'gcc -print-prog-name=as' returns 'as' without its path to the
native compiler. So this patch adds /usr/bin/as as the default assembler.

Signed-off-by: Ragner Magalhaes ragner.magalhaes@gmail.com
