### PR TITLE
Parse @file option

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -349,6 +349,8 @@ bool analyse_argv( const char * const *argv,
                 }
             } else
                 args.append( a, Arg_Rest );
+        } else if (a[0] == '@') {
+            args.append(a, Arg_Local);
         } else {
             args.append( a, Arg_Rest );
         }
@@ -381,7 +383,7 @@ bool analyse_argv( const char * const *argv,
             if ( it->first == "-Xclang" ) {
                 ++it;
                 ++it;
-            } else if ( it->second != Arg_Rest || it->first.at( 0 ) == '-' )
+            } else if ( it->second != Arg_Rest || it->first.at( 0 ) == '-' || it->first.at( 0 ) == '@' )
                 ++it;
             else if ( ifile.empty() ) {
 #if CLIENT_DEBUG


### PR DESCRIPTION
Implements support to parse @file option.
@file: Reads command-line options from file.

Signed-off-by: Ragner Magalhaes ragner.magalhaes@gmail.com
