### PR TITLE
Remove always_local to -include option

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -245,14 +245,11 @@ bool analyse_argv( const char * const *argv,
                 }
             } else if (str_equal("-include", a)) {
                 /* This has a duplicate meaning. it can either include a file
-                   for preprocessing or a precompiled header. decide which one.  */
+                   for preprocessing or a precompiled header. */
+                args.append(a, Arg_Local);
+
                 if (argv[i+1]) {
                     ++i;
-                    std::string p = argv[i];
-                    if (access(p.c_str(), R_OK) && access((p + ".gch").c_str(), R_OK))
-                        always_local = true;  /* can't decide which one, let the compiler figure it
-                                                 out.  */
-                    args.append(a, Arg_Local);
                     args.append(argv[i], Arg_Local);
                 }
             } else if (str_equal("-D", a)


### PR DESCRIPTION
The file to -include option is just the included file.
We shouldn't make the compilation always local just because we can't find a included file.
-include file: Process file as if "#include "file"" appeared as the first line of the primary source file.
The compilation of Android's C/C++ code is almost always local just because of the removed if clause.

Signed-off-by: Ragner Magalhaes ragner.magalhaes@gmail.com
