### PR TITLE
Replace four spaces by tabs on Makefiles

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,13 +1,13 @@
 ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = \
-    minilzo \
-    services \
-    daemon \
-    client \
-    doc \
-    suse \
-    compilerwrapper
+	minilzo \
+	services \
+	daemon \
+	client \
+	doc \
+	suse \
+	compilerwrapper
 
 dist-hook:
-    git log --date=short --pretty="format:@%cd  %an  <%ae>  [%H]%n%n%s%n%n%e%b" | sed -e "s|^\([^@]\)|\t\1|" -e "s|^@||" >$(distdir)/ChangeLog
+	git log --date=short --pretty="format:@%cd  %an  <%ae>  [%H]%n%n%s%n%n%e%b" | sed -e "s|^\([^@]\)|\t\1|" -e "s|^@||" >$(distdir)/ChangeLog

--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -1,36 +1,36 @@
 bin_PROGRAMS = icecc
 pkglibexec_SCRIPTS = icecc-create-env
 icecc_SOURCES = \
-    main.cpp \
-    arg.cpp \
-    cpp.cpp \
-    local.cpp \
-    remote.cpp \
-    util.cpp \
-    md5.c \
-    safeguard.cpp
+	main.cpp \
+	arg.cpp \
+	cpp.cpp \
+	local.cpp \
+	remote.cpp \
+	util.cpp \
+	md5.c \
+	safeguard.cpp
 icecc_LDADD = \
-    ../services/libicecc.la \
-    $(LIBRSYNC)
+	../services/libicecc.la \
+	$(LIBRSYNC)
 
 noinst_HEADERS = \
-    client.h \
-    md5.h \
-    util.h
+	client.h \
+	md5.h \
+	util.h
 AM_CPPFLAGS = \
-    -DPLIBDIR=\"$(pkglibexecdir)\" \
-    -I$(top_srcdir)/services
+	-DPLIBDIR=\"$(pkglibexecdir)\" \
+	-I$(top_srcdir)/services
 
 EXTRA_DIST = icecc-create-env
 
 install-exec-local:
-    $(mkinstalldirs) $(DESTDIR)$(bindir)
-    for link in g++ gcc c++ cc icerun $(CLANG_SYMLINK_WRAPPERS); do \
-      rm -f $(DESTDIR)$(bindir)/$$link ;\
-      $(LN_S) icecc $(DESTDIR)$(bindir)/$$link ;\
-    done
+	$(mkinstalldirs) $(DESTDIR)$(bindir)
+	for link in g++ gcc c++ cc icerun $(CLANG_SYMLINK_WRAPPERS); do \
+		rm -f $(DESTDIR)$(bindir)/$$link ;\
+		$(LN_S) icecc $(DESTDIR)$(bindir)/$$link ;\
+	done
 
 uninstall-local:
-    for link in g++ gcc c++ cc icerun $(CLANG_SYMLINK_WRAPPERS); do \
-      rm $(DESTDIR)$(bindir)/$$link ;\
-    done
+	for link in g++ gcc c++ cc icerun $(CLANG_SYMLINK_WRAPPERS); do \
+		rm $(DESTDIR)$(bindir)/$$link ;\
+	done

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -1,22 +1,24 @@
 sbin_PROGRAMS = iceccd
+
 iceccd_SOURCES = \
-    ncpus.c \
-    main.cpp \
-    serve.cpp \
-    workit.cpp \
-    environment.cpp \
-    load.cpp
+	ncpus.c \
+	main.cpp \
+	serve.cpp \
+	workit.cpp \
+	environment.cpp \
+	load.cpp
+
 iceccd_LDADD = \
-    ../services/libicecc.la \
-    $(LIB_KINFO) \
-    $(CAPNG_LDADD)
+	../services/libicecc.la \
+	$(LIB_KINFO) \
+	$(CAPNG_LDADD)
 
 AM_CPPFLAGS = \
-    -I$(top_srcdir)/services
-noinst_HEADERS = \
-    environment.h \
-    load.h \
-    ncpus.h \
-    serve.h \
-    workit.h
+	-I$(top_srcdir)/services
 
+noinst_HEADERS = \
+	environment.h \
+	load.h \
+	ncpus.h \
+	serve.h \
+	workit.h

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -6,4 +6,4 @@ KDE_MANS = AUTO
 #KDE_XSL_MAN_STYLESHEET = /usr/share/apps/ksgmltools2/customization/kde-man.xsl
 KDE_XSL_MAN_STYLESHEET = /opt/kde3/share/apps/ksgmltools2/customization/kde-man.xsl
 
-EXTRA_DIST =  man-icecc.1.docbook man-iceccd.1.docbook man-icecream.7.docbook man-scheduler.1.docbook
+EXTRA_DIST = man-icecc.1.docbook man-iceccd.1.docbook man-icecream.7.docbook man-scheduler.1.docbook

--- a/minilzo/Makefile.am
+++ b/minilzo/Makefile.am
@@ -7,17 +7,15 @@
 # ************************************************************************/
 
 AM_CPPFLAGS = \
-    -DMINILZO_HAVE_CONFIG_H \
-    -I$(top_srcdir)/include
-
+	-DMINILZO_HAVE_CONFIG_H \
+	-I$(top_srcdir)/include
 
 libminilzo_la_SOURCES = minilzo.c
 libminilzo_la_CFLAGS = -fPIC -DPIC
 noinst_LTLIBRARIES = libminilzo.la
 noinst_HEADERS = \
-    lzoconf.h \
-    minilzo.h \
-    lzodefs.h
+	lzoconf.h \
+	minilzo.h \
+	lzodefs.h
 
-EXTRA_DIST = README.LZO 
-
+EXTRA_DIST = README.LZO

--- a/services/Makefile.am
+++ b/services/Makefile.am
@@ -1,25 +1,27 @@
 AM_CPPFLAGS = \
-    -I$(top_srcdir)/minilzo
+	-I$(top_srcdir)/minilzo
 
 lib_LTLIBRARIES = libicecc.la
 libicecc_la_SOURCES = job.cpp comm.cpp getifaddrs.cpp logging.cpp tempfile.c platform.cpp gcc.cpp
 libicecc_la_LIBADD = \
-    ../minilzo/libminilzo.la \
-    -ldl
+	../minilzo/libminilzo.la \
+	-ldl
+
 libicecc_la_CFLAGS = -fPIC -DPIC
 libicecc_la_CXXFLAGS = -fPIC -DPIC
 
 icedir = $(includedir)/icecc
 ice_HEADERS = \
-    job.h \
-    comm.h
+	job.h \
+	comm.h
+
 noinst_HEADERS = \
-    bench.h \
-    exitcode.h \
-    getifaddrs.h \
-    logging.h \
-    tempfile.h \
-    platform.h
+	bench.h \
+	exitcode.h \
+	getifaddrs.h \
+	logging.h \
+	tempfile.h \
+	platform.h
 
 sbin_PROGRAMS = scheduler
 scheduler_SOURCES = scheduler.cpp

--- a/suse/Makefile.am
+++ b/suse/Makefile.am
@@ -1,7 +1,7 @@
 EXTRA_DIST = \
-    icecream.spec.in \
-    init.icecream \
-    logrotate \
-    SuSEfirewall.iceccd \
-    SuSEfirewall.scheduler \
-    sysconfig.icecream
+	icecream.spec.in \
+	init.icecream \
+	logrotate \
+	SuSEfirewall.iceccd \
+	SuSEfirewall.scheduler \
+	sysconfig.icecream


### PR DESCRIPTION
Makefiles should use tabs instead of whitespaces

Signed-off-by: Rodrigo Belem rodrigo.belem@gmail.com
