### PR TITLE
Rename scheduler to icecc-scheduler to avoid name clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ How to use icecream
 
 You need:
 
--   One machine that runs the scheduler ("./scheduler -d")
+-   One machine that runs the scheduler ("./icecc-scheduler -d")
 -   Many machines that run the daemon ("./iceccd -d")
 
 It is possible to run the scheduler and the daemon on one machine and

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,17 +1,17 @@
 STYLESHEET=$(shell kde4-config --path data --locate ksgmltools2/customization/kde-include-man.xsl)
 MEINPROC=meinproc4 --stylesheet $(STYLESHEET)
 icecc.1: $(srcdir)/man-icecc.1.docbook
-	$(MEINPROC) $(srcdir)/man-icecc.1.docbook 
+	$(MEINPROC) $(srcdir)/man-icecc.1.docbook
 
-scheduler.1: $(srcdir)/man-scheduler.1.docbook
-	$(MEINPROC) $(srcdir)/man-scheduler.1.docbook 
+icecc-scheduler.1: $(srcdir)/man-icecc-scheduler.1.docbook
+	$(MEINPROC) $(srcdir)/man-icecc-scheduler.1.docbook
 
 iceccd.1: $(srcdir)/man-iceccd.1.docbook
-	$(MEINPROC) $(srcdir)/man-iceccd.1.docbook 
+	$(MEINPROC) $(srcdir)/man-iceccd.1.docbook
 
 icecream.7: $(srcdir)/man-icecream.7.docbook
 	$(MEINPROC) $(srcdir)/man-icecream.7.docbook
 
-dist_man_MANS = icecc.1 iceccd.1 icecream.7 scheduler.1
+dist_man_MANS = icecc.1 iceccd.1 icecc-scheduler.1 icecream.7
 
-EXTRA_DIST = man-icecc.1.docbook man-iceccd.1.docbook man-icecream.7.docbook man-scheduler.1.docbook
+EXTRA_DIST = man-icecc.1.docbook man-iceccd.1.docbook man-icecc-scheduler.1.docbook man-icecream.7.docbook

--- a/doc/man-icecc-scheduler.1.docbook
+++ b/doc/man-icecc-scheduler.1.docbook
@@ -23,13 +23,13 @@
 </refmeta>
 
 <refnamediv>
-	<refname>scheduler</refname>
+	<refname>icecc-scheduler</refname>
 	<refpurpose>Icecream scheduler</refpurpose>
 </refnamediv>
 
 <refsynopsisdiv>
 <cmdsynopsis>
-<command>scheduler</command>
+<command>icecc-scheduler</command>
 <group>
   <arg choice="opt">
     <option>-n</option>
@@ -151,7 +151,7 @@ need to run the scheduler with root rights.</para></listitem>
 
 <refsect1>
 <title>See Also</title>
-<para>icecream, scheduler, iceccd, icemon</para>
+<para>icecream, iceccd, icemon</para>
 </refsect1>
 
 <refsect1>

--- a/doc/man-icecc.1.docbook
+++ b/doc/man-icecc.1.docbook
@@ -49,7 +49,7 @@ stubs in your path:
 
 <refsect1>
 <title>See Also</title>
-<para>icecream, scheduler, iceccd, icemon</para>
+<para>icecream, icecc-scheduler, iceccd, icemon</para>
 </refsect1>
 
 <refsect1>

--- a/doc/man-iceccd.1.docbook
+++ b/doc/man-iceccd.1.docbook
@@ -205,7 +205,7 @@ environments of compile clients.</para></listitem>
 
 <refsect1>
 <title>See Also</title>
-<para>icecream, scheduler, iceccd, icemon</para>
+<para>icecream, icecc-scheduler, iceccd, icemon</para>
 </refsect1>
 
 <refsect1>

--- a/doc/man-icecream.7.docbook
+++ b/doc/man-icecream.7.docbook
@@ -48,7 +48,7 @@ over them anyway.</para>
 <para>You need:</para>
 <itemizedlist>
 <listitem>
-  <para>One machine that runs the scheduler ("./scheduler -d")</para>
+  <para>One machine that runs the scheduler ("./icecc-scheduler -d")</para>
 </listitem>
 <listitem>
   <para>Many machines that run the daemon ("./iceccd -d")</para>
@@ -321,7 +321,7 @@ USE_SCHEDULER=&lt;host&gt; icemon (or send me a patch :)</para>
 
 <refsect1>
 <title>See Also</title>
-<para>icecream, scheduler, iceccd, icemon</para>
+<para>icecream, icecc-scheduler, iceccd, icemon</para>
 </refsect1>
 
 <refsect1>

--- a/services/Makefile.am
+++ b/services/Makefile.am
@@ -23,9 +23,9 @@ noinst_HEADERS = \
 	tempfile.h \
 	platform.h
 
-sbin_PROGRAMS = scheduler
-scheduler_SOURCES = scheduler.cpp
-scheduler_LDADD = libicecc.la
+sbin_PROGRAMS = icecc-scheduler
+icecc_scheduler_SOURCES = scheduler.cpp
+icecc_scheduler_LDADD = libicecc.la
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = icecc.pc

--- a/services/scheduler.cpp
+++ b/services/scheduler.cpp
@@ -1877,7 +1877,7 @@ usage(const char* reason = 0)
      cerr << reason << endl;
 
   cerr << "ICECREAM scheduler " VERSION "\n";
-  cerr << "usage: scheduler [options] \n"
+  cerr << "usage: icecc-scheduler [options] \n"
        << "Options:\n"
        << "  -n, --netname <name>\n"
        << "  -p, --port <port>\n"


### PR DESCRIPTION
Now with documentation updated.

Signed-off-by: Rodrigo Belem rodrigo.belem@gmail.com
