### PR TITLE
Fix docbook2x dependence

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,12 +70,12 @@ AC_ARG_WITH(man,
 )
 AS_IF([test "x$with_man" != "xno"], [
     build_man=yes
-    AC_PATH_PROG(DOCBOOK2X,[docbook-to-man])
+    AC_PATH_PROG(DOCBOOK2X,[docbook2x-man])
     AS_IF([test -z "$DOCBOOK2X"], [
         AC_PATH_PROG(DOCBOOK2X,[docbook2man.pl])
         AS_IF([test -z "$DOCBOOK2X"], [
-            AC_MSG_WARN([docbook-to-man is missing. Install docbook2X package.])
-            DOCBOOK2X='echo docbook-to-man is missing. Install docbook2X package.'
+            AC_MSG_WARN([docbook2x-man is missing. Install docbook2X package.])
+            DOCBOOK2X='echo docbook2x-man is missing. Install docbook2X package.'
         ])
     ])
 ], [build_man=no])


### PR DESCRIPTION
Replaces docbook-to-man by docbook2x-man command to generate the man
files because icecream depends of docbook2x instead of docbook-to-man
package.

Signed-off-by: Ragner Magalhaes ragner.magalhaes@gmail.com
