### PR TITLE
fix clang wrappers build in specfile

### DIFF
--- a/suse/icecream.spec.in
+++ b/suse/icecream.spec.in
@@ -71,8 +71,8 @@ export CXXFLAGS="$RPM_OPT_FLAGS"
 %configure \
 %if 0%{?suse_version} >= 1230
     --enable-clang-rewrite-includes \
-    --enable-clang-wrappers \
 %endif
+    --enable-clang-wrappers \
     --libexecdir %_libexecdir
 make %{?jobs:-j %jobs}
 


### PR DESCRIPTION
The package is unconditionally built, so the wrappers should be
unconditional too, even if they don't get actually used without clang.
