### PR TITLE
Fix icerun-wrapped commands failing if the command's path contains 'clang' anywhere

### DIFF
--- a/client/local.cpp
+++ b/client/local.cpp
@@ -118,6 +118,9 @@ string find_compiler( const CompileJob& job )
 
 bool compiler_is_clang( const CompileJob& job )
 {
+    if( job.language() == CompileJob::Lang_Custom )
+        return false;
+    assert( job.compilerName().find( '/' ) == string::npos );
     return job.compilerName().find("clang") != string::npos;
 }
 


### PR DESCRIPTION
I think this one should go in 1.0 , a custom command obviously cannot be done using Clang compiler, and the assert also should not trigger, since non-custom builds have path stripped from the compiler name, so it should be safe.

Whenever a command run using icerun contains 'clang' anywhere in the command's path, icecream will add -fcolor-diagnostics to the arguments, making the command most likely to fail. At least both KDE and LibreOffice use icerun in their build system, and they'll both fail if e.g. the username contains 'clang' in it, or if somebody does a Clang-based build and puts it in a directory called 'clang'.
