### PR TITLE
Fix buffer overflow when calling icecc-create-env

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -170,7 +170,7 @@ static int create_native( char** args )
     int extracount = 0;
     while ( extrafiles[ extracount ] )
         ++extracount;
-    char **argv = new char*[4+extracount*2];
+    char **argv = new char*[5+extracount*2];
     int pos = 0;
     struct stat st;
     if ( lstat( PLIBDIR "/icecc-create-env", &st ) ) {


### PR DESCRIPTION
There are 1 program name + 3 arguments + the finishing NULL == 5
(+ extracount_2 arguments)
This could e.g. lead to "argv[pos++] = NULL" overwriting the contents of the
first strdup that follows "new char_[4+extracount*2]" (leading to
failing icecc-create-env call).
