### PR TITLE
Enable icecc to find compilers outside PATH

### DIFF
--- a/client/local.cpp
+++ b/client/local.cpp
@@ -42,10 +42,10 @@ extern const char *rs_program_name;
 
 #define CLIENT_DEBUG 0
 
-string compiler_path_lookup(const string &compiler)
+static string compiler_path_lookup_helper(const string &compiler, const string &original_compiler)
 {
-    if (compiler.at(0) == '/') {
-        return compiler;
+    if (original_compiler.find_first_of('/') != string::npos) {
+        return original_compiler;
     }
 
     string path = ::getenv("PATH");
@@ -110,6 +110,11 @@ string compiler_path_lookup(const string &compiler)
     return best_match;
 }
 
+string compiler_path_lookup(const string& compiler)
+{
+    return compiler_path_lookup_helper(compiler, compiler);
+}
+
 /*
  * Get the name of the compiler depedant on the
  * language of the job and the environment
@@ -130,7 +135,7 @@ string find_compiler(const CompileJob &job)
         }
     }
 
-    return compiler_path_lookup(job.compilerName());
+    return compiler_path_lookup_helper(job.compilerName(), job.originalCompilerName());
 }
 
 bool compiler_is_clang(const CompileJob &job)

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -284,6 +284,7 @@ int main(int argc, char **argv)
 
             if (arg.size() > 0) {
                 job.setCompilerName(arg);
+                job.setOriginalCompilerName(arg);
             }
         }
     } else if (find_basename(compiler_name) == "icerun") {

--- a/services/job.h
+++ b/services/job.h
@@ -44,6 +44,9 @@ public:
     void setCompilerName(const std::string& name) { m_compiler_name = name; }
     std::string compilerName() const { return m_compiler_name; }
 
+    void setOriginalCompilerName(const std::string& name) { m_original_compiler_name = name; }
+    std::string originalCompilerName() const { return m_original_compiler_name; }
+
     void setLanguage( Language lg ) { m_language = lg; }
     Language language() const { return m_language; }
 
@@ -103,6 +106,7 @@ private:
 
     unsigned int m_id;
     Language m_language;
+    std::string m_original_compiler_name;
     std::string m_compiler_name;
     std::string m_environment_version;
     ArgumentsList m_flags;


### PR DESCRIPTION
Teach find_compiler and friends to conditionally use the original
compiler name. This enables users to have (cross-)compilers outside
PATH, and is especially useful in combination with ccache and
CCACHE_PREFIX. In this case no directory of symbolic links is needed
nor does the (cross-)compiler have to be in the PATH.

Accomplish this by saving away the original, full compiler path/name
and use it in cases when the original name looks like an absolute or
relative path.

Signed-off-by: David Vest davve@opera.com
