### PR TITLE
Fix off-by-one error

### DIFF
--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -163,12 +163,12 @@ rip_out_paths(const Environments &envs, map<string, string> &version_map, map<st
 
     Environments env2;
 
-    static const char *suffs[] = { ".tar.bz2", ".tar.gz", ".tar", ".tgz" };
+    static const char *suffs[] = { ".tar.bz2", ".tar.gz", ".tar", ".tgz", NULL };
 
     string versfile;
 
     for (Environments::const_iterator it = envs.begin(); it != envs.end(); ++it) {
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; suffs[i] != NULL; i++)
             if (endswith(it->second, suffs[i], versfile)) {
                 versionfile_map[it->first] = it->second;
                 versfile = find_basename(versfile);


### PR DESCRIPTION
The array 'suffs' has four entries. The nested for-loop, however, only
traversed up to the third entry and failed to reach the fourth entry
'.tgz'.

Signed-off-by: David Vest davve@opera.com
