### PR TITLE
Enable icecc to find compilers outside PATH when building locally

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -91,7 +91,6 @@ static bool analyze_program(const char *name, CompileJob &job)
         job.setLanguage(CompileJob::Lang_C);
     } else {
         job.setLanguage(CompileJob::Lang_Custom);
-        job.setCompilerName(name);   // keep path
         return true;
     }
 

--- a/client/local.cpp
+++ b/client/local.cpp
@@ -44,10 +44,10 @@ extern const char *rs_program_name;
 
 #define CLIENT_DEBUG 0
 
-string compiler_path_lookup(const string &compiler)
+static string compiler_path_lookup_helper(const string &compiler, const string &compiler_path)
 {
-    if (compiler.at(0) == '/') {
-        return compiler;
+    if (compiler_path.find_first_of('/') != string::npos) {
+        return compiler_path;
     }
 
     string path = ::getenv("PATH");
@@ -112,6 +112,11 @@ string compiler_path_lookup(const string &compiler)
     return best_match;
 }
 
+string compiler_path_lookup(const string& compiler)
+{
+    return compiler_path_lookup_helper(compiler, compiler);
+}
+
 /*
  * Get the name of the compiler depedant on the
  * language of the job and the environment
@@ -132,7 +137,7 @@ string find_compiler(const CompileJob &job)
         }
     }
 
-    return compiler_path_lookup(job.compilerName());
+    return compiler_path_lookup_helper(job.compilerName(), job.compilerPathname());
 }
 
 bool compiler_is_clang(const CompileJob &job)

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -285,6 +285,7 @@ int main(int argc, char **argv)
 
             if (arg.size() > 0) {
                 job.setCompilerName(arg);
+                job.setCompilerPathname(arg);
             }
         }
     } else if (find_basename(compiler_name) == "icerun") {

--- a/services/job.h
+++ b/services/job.h
@@ -86,6 +86,16 @@ public:
         return m_language;
     }
 
+    void setCompilerPathname(const std::string& pathname)
+    {
+        m_compiler_pathname = pathname;
+    }
+
+    std::string compilerPathname() const
+    {
+        return m_compiler_pathname;
+    }
+
     void setEnvironmentVersion(const std::string &ver)
     {
         m_environment_version = ver;
@@ -158,6 +168,7 @@ private:
 
     unsigned int m_id;
     Language m_language;
+    std::string m_compiler_pathname;
     std::string m_compiler_name;
     std::string m_environment_version;
     ArgumentsList m_flags;


### PR DESCRIPTION
Teach find_compiler and friends to conditionally use the full compiler
path name. This enables users to have (cross-)compilers outside PATH,
and is especially useful in combination with ccache and CCACHE_PREFIX.
In this case no directory of symbolic links is needed nor does the
(cross-)compiler have to be in the PATH.

Accomplish this by saving away the full compiler name and use it in
cases when the compiler name looks like an absolute or relative path.

Signed-off-by: David Vest davve@opera.com
