### PR TITLE
__gnu_cxx namespace is no longer needed

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -109,7 +109,6 @@ static std::string pidFilePath;
 #endif
 
 using namespace std;
-using namespace __gnu_cxx; // for the extensions we like, e.g. hash_set
 
 struct Client {
 public:


### PR DESCRIPTION
It was introduced in 2006 for hash_set but hash_set is no longer used now. Plus it will break building with clang.
