### PR TITLE
Added missing headers to fix 'make dist'.

### DIFF
--- a/scheduler/Makefile.am
+++ b/scheduler/Makefile.am
@@ -2,3 +2,9 @@
 sbin_PROGRAMS = icecc-scheduler
 icecc_scheduler_SOURCES = compileserver.cpp job.cpp jobstat.cpp scheduler.cpp
 icecc_scheduler_LDADD = ../services/libicecc.la
+
+noinst_HEADERS = \
+    bench.h \
+    compileserver.h \
+    job.h \
+    jobstat.h


### PR DESCRIPTION
Looks like make dist is broken on master:

make dist works, but when running make on the extracted distribution:

Making all in scheduler
  CXX      compileserver.o
compileserver.cpp:24:27: error: compileserver.h: No such file or directory
compileserver.cpp:32:17: error: job.h: No such file or directory
...
