### PR TITLE
Add support for "-x c++" and "-x c" options

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -257,7 +257,6 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                 always_local = true;
                 args.append(a, Arg_Local);
             } else if (!strcmp(a, "-x")) {
-                bool local = false;
                 const char *opt = argv[++i];
 
                 if (!strcmp, opt, "c++") {
@@ -265,18 +264,11 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                 } else if (!strcmp, opt, "c") {
                     job.setLanguage(CompileJob::Lang_C);
                 } else {
-                    local = true;
 #if CLIENT_DEBUG
                     log_info() << "unsupported -x option; running locally" << endl;
 #endif
-                }
-
-                if (local) {
                     always_local = true;
                     args.append(a, Arg_Local);
-                } else {
-                    args.append(a, Arg_Remote);
-                    args.append(opt, Arg_Remote);
                 }
             } else if (!strcmp(a, "-march=native") || !strcmp(a, "-mcpu=native")
                        || !strcmp(a, "-mtune=native")) {


### PR DESCRIPTION
These options simply select the compiler language. At least Boost.Build uses this feature. All other (rare) cases are still handled locally.
