### PR TITLE
better logging for 'eof && !HAS_MSG'

### DIFF
--- a/services/comm.cpp
+++ b/services/comm.cpp
@@ -982,8 +982,8 @@ Msg *MsgChannel::get_msg(int timeout)
     /* If we've seen the EOF, and we don't have a complete message,
        then we won't see it anymore.  Return that to the caller.
        Don't use has_msg() here, as it returns true for eof.  */
-    if (eof && instate != HAS_MSG) {
-        trace() << "eof && !HAS_MSG\n";
+    if (at_eof()) {
+        trace() << "saw eof without complete msg! " << instate << endl;
         return 0;
     }
 


### PR DESCRIPTION
I'm trying to debug some situations that fall back to local compilation for no obvious reason, where my logs show lots of "eof && !HAS_MSG" messages.  This patch logs the value of instate as in a similar log a few lines below, and uses the at_eof() function instead of duplicating the check condition.
