### PR TITLE
Use std::endl instead of trailing \n in logging to flush output buffers

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -181,7 +181,7 @@ static int create_native(char **args)
     struct stat st;
 
     if (lstat(PLIBDIR "/icecc-create-env", &st)) {
-        log_error() << PLIBDIR "/icecc-create-env does not exist\n";
+        log_error() << PLIBDIR "/icecc-create-env does not exist" << endl;
         return 1;
     }
 
@@ -191,12 +191,12 @@ static int create_native(char **args)
         string clang = compiler_path_lookup("clang");
 
         if (clang.empty()) {
-            log_error() << "clang compiler not found\n";
+            log_error() << "clang compiler not found" << endl;
             return 1;
         }
 
         if (lstat(PLIBDIR "/compilerwrapper", &st)) {
-            log_error() << PLIBDIR "/compilerwrapper does not exist\n";
+            log_error() << PLIBDIR "/compilerwrapper does not exist" << endl;
             return 1;
         }
 
@@ -218,7 +218,7 @@ static int create_native(char **args)
 
         // both C and C++ compiler are required
         if (gcc.empty() || gpp.empty()) {
-            log_error() << "gcc compiler not found\n";
+            log_error() << "gcc compiler not found" << endl;
             return 1;
         }
 
@@ -403,13 +403,13 @@ int main(int argc, char **argv)
     } else {
         local_daemon = Service::createChannel(getenv("ICECC_TEST_SOCKET"));
         if (!local_daemon) {
-            log_error() << "test socket error\n";
+            log_error() << "test socket error" << endl;
             return EXIT_TEST_SOCKET_ERROR;
         }
     }
 
     if (!local_daemon) {
-        log_warning() << "no local daemon found\n";
+        log_warning() << "no local daemon found" << endl;
         return build_local(job, 0);
     }
 
@@ -423,12 +423,12 @@ int main(int argc, char **argv)
                 // we just build locally
             }
         } else if (!extrafiles.empty() && !IS_PROTOCOL_32(local_daemon)) {
-            log_warning() << "Local daemon is too old to handle compiler plugins.\n";
+            log_warning() << "Local daemon is too old to handle compiler plugins." << endl;
             local = true;
         } else {
             if (!local_daemon->send_msg(GetNativeEnvMsg(compiler_is_clang(job)
                                         ? "clang" : "gcc", extrafiles))) {
-                log_warning() << "failed to write get native environment\n";
+                log_warning() << "failed to write get native environment" << endl;
                 goto do_local_error;
             }
 

--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -732,7 +732,7 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
     Environments envs = rip_out_paths(_envs, version_map, versionfile_map);
 
     if (!envs.size()) {
-        log_error() << "$ICECC_VERSION needs to point to .tar files\n";
+        log_error() << "$ICECC_VERSION needs to point to .tar files" << endl;
         throw(22);
     }
 
@@ -760,7 +760,7 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
                        minimalRemoteVersion(job));
 
         if (!local_daemon->send_msg(getcs)) {
-            log_warning() << "asked for CS\n";
+            log_warning() << "asked for CS" << endl;
             throw(24);
         }
 
@@ -808,7 +808,7 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
 
 
         if (!local_daemon->send_msg(getcs)) {
-            log_warning() << "asked for CS\n";
+            log_warning() << "asked for CS" << endl;
             throw(0);
         }
 

--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -399,7 +399,7 @@ int start_create_env(const string &basedir, uid_t user_uid, gid_t user_gid,
     argv[pos++] = NULL;
 
     if (!exec_and_wait(argv)) {
-        log_error() << BINDIR "/icecc --build-native failed\n";
+        log_error() << BINDIR "/icecc --build-native failed" << endl;
         _exit(1);
     }
 

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -1758,7 +1758,7 @@ int Daemon::answer_client_requests()
                 Msg *msg = scheduler->get_msg();
 
                 if (!msg) {
-                    log_error() << "scheduler closed connection\n";
+                    log_error() << "scheduler closed connection" << endl;
                     close_scheduler();
                     clear_children();
                     return 1;
@@ -1924,7 +1924,7 @@ bool Daemon::reconnect()
     scheduler = discover->try_get_scheduler();
 
     if (!scheduler) {
-        log_warning() << "scheduler not yet found.\n";
+        log_warning() << "scheduler not yet found." << endl;
         return false;
     }
 
@@ -1940,7 +1940,7 @@ bool Daemon::reconnect()
         remote_name = string();
     }
 
-    log_info() << "Connected to scheduler (I am known as " << remote_name << ")\n";
+    log_info() << "Connected to scheduler (I am known as " << remote_name << ")" << endl;
     current_load = -1000;
     gettimeofday(&last_stat, 0);
     icecream_load = 0;
@@ -2232,7 +2232,7 @@ int main(int argc, char **argv)
         max_kids = max_processes;
     }
 
-    log_info() << "allowing up to " << max_kids << " active jobs\n";
+    log_info() << "allowing up to " << max_kids << " active jobs" << endl;
 
     int ret;
 

--- a/daemon/serve.cpp
+++ b/daemon/serve.cpp
@@ -86,7 +86,7 @@ static void write_output_file( const string& file, MsgChannel* client )
         obj_fd = open(file.c_str(), O_RDONLY | O_LARGEFILE);
 
         if (obj_fd == -1) {
-            log_error() << "open failed\n";
+            log_error() << "open failed" << endl;
             error_client(client, "open of object file failed");
             throw myexception(EXIT_DISTCC_FAILED);
         }
@@ -216,7 +216,7 @@ int handle_connection(const string &basedir, CompileJob *job,
         }
 
         if (!client->send_msg(rmsg)) {
-            log_info() << "write of result failed\n";
+            log_info() << "write of result failed" << endl;
             throw myexception(EXIT_DISTCC_FAILED);
         }
 

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -383,7 +383,7 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client,
                         job_stat[JobStatistics::in_uncompressed] += fcmsg->len;
                         job_stat[JobStatistics::in_compressed] += fcmsg->compressed;
                     } else {
-                        log_error() << "protocol error while reading preprocessed file\n";
+                        log_error() << "protocol error while reading preprocessed file" << endl;
                         return_value = EXIT_IO_ERROR;
                         client_fd = -1;
                         kill(pid, SIGTERM);
@@ -393,7 +393,7 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client,
                     }
                 }
             } else if (client->at_eof()) {
-                log_error() << "unexpected EOF while reading preprocessed file\n";
+                log_error() << "unexpected EOF while reading preprocessed file" << endl;
                 return_value = EXIT_IO_ERROR;
                 client_fd = -1;
                 kill(pid, SIGTERM);
@@ -456,7 +456,7 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client,
         case 0:
 
             if (!input_complete) {
-                log_error() << "timeout while reading preprocessed file\n";
+                log_error() << "timeout while reading preprocessed file" << endl;
                 kill(pid, SIGTERM); // Won't need it any more ...
                 return_value = EXIT_IO_ERROR;
                 client_fd = -1;

--- a/services/comm.cpp
+++ b/services/comm.cpp
@@ -1336,7 +1336,7 @@ void DiscoverSched::attempt_scheduler_connect()
 {
 
     time0 = time(0) + MAX_SCHEDULER_PONG;
-    log_info() << "scheduler is on " << schedname << ":" << sport << " (net " << netname << ")\n";
+    log_info() << "scheduler is on " << schedname << ":" << sport << " (net " << netname << ")" << endl;
 
     if ((ask_fd = prepare_connect(schedname, sport, remote_addr)) >= 0) {
         fcntl(ask_fd, F_SETFL, O_NONBLOCK);


### PR DESCRIPTION
Currently icecc log file is somewhat inconvenient to follow -- output buffering sometimes delays it quite a bit.
Use std::endl to flush buffers at the end of log line.
