### PR TITLE
Fix crash when start_install_environment fails (issue #103)

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -929,10 +929,10 @@ bool Daemon::handle_transfer_env(Client *client, Msg *_msg)
 
     client->status = Client::TOINSTALL;
     client->outfile = emsg->target + "/" + emsg->name;
+    current_kids++;
 
     if (pid > 0) {
         log_error() << "got pid " << pid << endl;
-        current_kids++;
         client->pipe_to_child = sock_to_stdin;
         client->child_pid = pid;
 


### PR DESCRIPTION
When start_install_environment fails (returns <=0) the code immediatelly
proceeds to handle_transfer_env_done where current_kids is decremented
after asserting it's >0. However, current_kids is only incremented if
start_install_environment returned >0, creating an inconsistency that
leads to a crash. The simple fix is to always increment current_kids.
