### PR TITLE
Icecc daemon crashes when ICECC_VERSION contains a filename with dot as first char (#70)

### DIFF
--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -442,7 +442,7 @@ pid_t start_install_environment(const std::string &basename, const std::string &
                                 int &pipe_to_stdin, FileChunkMsg *&fmsg,
                                 uid_t user_uid, gid_t user_gid)
 {
-    if (!name.size() || (name[0] == '.')) {
+    if (!name.size()) {
         log_error() << "illegal name for environment " << name << endl;
         return 0;
     }

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -969,8 +969,9 @@ bool Daemon::handle_transfer_env_done(Client *client)
     string current = client->outfile;
     client->outfile.clear();
     client->child_pid = -1;
-    assert(current_kids > 0);
-    current_kids--;
+    if (current_kids > 0) {
+        current_kids--;
+    }
 
     log_error() << "installed_size: " << installed_size << endl;
 


### PR DESCRIPTION
- Don't consider filenames starting with dot as illegal.
- Instead of asserting, use a simple if.
