### PR TITLE
Fix the creation of a native environment on MacOS (#79)

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -304,10 +304,8 @@ done
 if test "$is_darwin" = 1; then
     # add dynamic linker
     add_file /usr/lib/dyld
-    real_file=`/usr/bin/gcc --version | head -n 1 2>&1 | cut -d" " -f1`
-    add_file /usr/bin/$real_file
-    real_file=`/usr/bin/g++ --version | head -n 1 2>&1 | cut -d" " -f1`
-    add_file /usr/bin/$real_file
+    add_file /usr/bin/gcc
+    add_file /usr/bin/g++
     real_file=`/usr/bin/as -micha -- < /dev/null 2>&1 | sed -n 's,^[^/]*\(/[^ :]*\).*,\1,p'`
     add_file $(abs_path "$real_file")
 fi

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -60,6 +60,7 @@
 #include <sys/wait.h>
 
 #include "client.h"
+#include "platform.h"
 
 using namespace std;
 
@@ -169,10 +170,13 @@ static int create_native(char **args)
 {
     bool is_clang = false;
     char **extrafiles = args;
+    string machine_name = determine_platform();
 
+    if (machine_name.find("Darwin") == 0)
+        is_clang = true;
     // Args[0] may be a compiler or the first extra file.
     if (args[0] && ((!strcmp(args[0], "clang") && (is_clang = true))
-                    || !strcmp(args[0], "gcc"))) {
+                    || (!strcmp(args[0], "gcc") && (is_clang = false)))) {
         extrafiles++;
     }
 


### PR DESCRIPTION
  * Clang is the default compiler on MacOS, so "icecc --build-native"
    should default to build a Clang toolchain on MacOS.

  * Fix on icecc-create-env the detection of the path for gcc.