### PR TITLE
client: add and use an helper get_cwd()

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -61,6 +61,7 @@
 
 #include "client.h"
 #include "platform.h"
+#include "util.h"
 
 using namespace std;
 
@@ -269,8 +270,8 @@ int main(int argc, char **argv)
     string compiler_name = argv[0];
     dcc_client_catch_signals();
 
-    char cwd[ PATH_MAX ];
-    if( getcwd( cwd, PATH_MAX ) != NULL )
+    std::string cwd = get_cwd();
+    if(!cwd.empty())
         job.setWorkingDirectory( cwd );
 
     if (find_basename(compiler_name) == rs_program_name) {

--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -51,6 +51,7 @@
 #include "client.h"
 #include "tempfile.h"
 #include "md5.h"
+#include "util.h"
 #include "services/util.h"
 
 #ifndef O_LARGEFILE
@@ -191,13 +192,7 @@ get_absfilename(const string &_file)
     }
 
     if (_file.at(0) != '/') {
-        static std::vector<char> buffer(1024);
-
-        while (getcwd(&buffer[0], buffer.size() - 1) == 0 && errno == ERANGE) {
-            buffer.resize(buffer.size() + 1024);
-        }
-
-        file = string(&buffer[0]) + '/' + _file;
+        file = get_cwd() + '/' + _file;
     } else {
         file = _file;
     }

--- a/client/util.cpp
+++ b/client/util.cpp
@@ -38,6 +38,8 @@
 #include <sys/stat.h>
 #include <sys/file.h>
 
+#include <vector>
+
 #include "client.h"
 #include "exitcode.h"
 #include "job.h"
@@ -348,4 +350,19 @@ int resolve_link(const std::string &file, std::string &resolved)
     buf[ret] = 0;
     resolved = std::string(buf);
     return 0;
+}
+
+std::string get_cwd()
+{
+    static std::vector<char> buffer(1024);
+
+    errno = 0;
+    while (getcwd(&buffer[0], buffer.size() - 1) == 0 && errno == ERANGE) {
+        buffer.resize(buffer.size() + 1024);
+        errno = 0;
+    }
+    if (errno != 0)
+        return std::string();
+
+    return string(&buffer[0]);
 }

--- a/client/util.h
+++ b/client/util.h
@@ -36,6 +36,7 @@ extern bool compiler_has_color_output(const CompileJob &job);
 extern bool output_needs_workaround(const CompileJob &job);
 extern bool ignore_unverified();
 extern int resolve_link(const std::string &file, std::string &resolved);
+extern std::string get_cwd();
 
 extern bool dcc_unlock(int lock_fd);
 extern bool dcc_lock_host(int &lock_fd);


### PR DESCRIPTION
Move the `getcwd()` code from `get_absfilename()` into an own `get_cwd()` helper, using it where needed.
