### PR TITLE
Few cleanups of unneeded configure headers/functions checks

### DIFF
--- a/client/local.cpp
+++ b/client/local.cpp
@@ -32,9 +32,7 @@
 #include <string.h>
 #include <errno.h>
 #include <vector>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include <comm.h>
 #include "client.h"

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -54,9 +54,7 @@
 #include <comm.h>
 #include <vector>
 #include <sys/types.h>
-#ifdef HAVE_SYS_STAT_H
-#  include <sys/stat.h>
-#endif
+#include <sys/stat.h>
 #include <sys/wait.h>
 
 #include "client.h"

--- a/configure.ac
+++ b/configure.ac
@@ -92,26 +92,15 @@ AM_CONDITIONAL([WITH_ICECREAM_MAN], [test "x$build_man" != "xno"])
 
 # Some of these are needed by popt (or other libraries included in the future).
 
-AC_CHECK_HEADERS([unistd.h stdint.h signal.h sys/types.h sys/signal.h ifaddrs.h kinfo.h sys/param.h devstat.h])
-AC_CHECK_HEADERS([sys/resource.h sys/socket.h sys/socketvar.h sys/stat.h sys/select.h sys/vfs.h])
+AC_CHECK_HEADERS([sys/signal.h ifaddrs.h kinfo.h sys/param.h devstat.h])
+AC_CHECK_HEADERS([sys/socketvar.h sys/vfs.h])
 AC_CHECK_HEADERS([mach/host_info.h])
-AC_CHECK_HEADERS([netinet/in.h], [], [],
-[#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-])
 AC_CHECK_HEADERS([arpa/nameser.h], [], [],
-[#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
+[#include <sys/types.h>
 ])
 AC_CHECK_HEADERS([resolv.h], [], [],
-[#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
+[#include <sys/types.h>
+#include <netinet/in.h>
 #if HAVE_ARPA_NAMESER_H
 # include <arpa/nameser.h>
 #endif
@@ -120,20 +109,13 @@ AC_CHECK_HEADERS([resolv.h], [], [],
 AC_ARG_VAR(TAR, [Specifies tar path])
 AC_PATH_PROG(TAR, [tar])
 AC_DEFINE_UNQUOTED([TAR], ["$TAR"], [Define path to tar])
-AC_CHECK_HEADERS([netinet/tcp.h])
 AC_CHECK_HEADERS([netinet/tcp_var.h], [], [],
-[#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
+[#include <sys/types.h>
 #if HAVE_SYS_SOCKETVAR_H
 # include <sys/socketvar.h>
 #endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#if HAVE_NETINET_TCP_H
-# include <netinet/tcp.h>
-#endif
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 ])
 
 AC_CHECK_HEADERS([sys/user.h])
@@ -143,15 +125,9 @@ dnl Checks for types
 
 AC_CHECK_TYPES([sa_family_t, socklen_t, in_port_t, in_addr_t], , ,
 	       [
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_SYS_SOCKET_H
-# include <sys/socket.h>
-#endif
-#if HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #if HAVE_ARPA_NAMESER_H
 # include <arpa/nameser.h>
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -178,7 +178,6 @@ if test x"$ac_cv_func_connect" = x"no"; then
 fi
 
 AC_CHECK_FUNCS([flock lockf])
-AC_CHECK_FUNCS([wait4 setgroups])
 AC_CHECK_FUNCS([strsignal])
 AC_CHECK_FUNCS([getloadavg])
 

--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,7 @@ AM_CONDITIONAL([WITH_ICECREAM_MAN], [test "x$build_man" != "xno"])
 # Some of these are needed by popt (or other libraries included in the future).
 
 AC_CHECK_HEADERS([unistd.h stdint.h signal.h sys/types.h sys/signal.h ifaddrs.h kinfo.h sys/param.h devstat.h])
-AC_CHECK_HEADERS([ctype.h sys/resource.h sys/socket.h sys/socketvar.h sys/stat.h sys/select.h sys/vfs.h])
+AC_CHECK_HEADERS([sys/resource.h sys/socket.h sys/socketvar.h sys/stat.h sys/select.h sys/vfs.h])
 AC_CHECK_HEADERS([mach/host_info.h])
 AC_CHECK_HEADERS([netinet/in.h], [], [],
 [#if HAVE_SYS_TYPES_H
@@ -120,7 +120,7 @@ AC_CHECK_HEADERS([resolv.h], [], [],
 AC_ARG_VAR(TAR, [Specifies tar path])
 AC_PATH_PROG(TAR, [tar])
 AC_DEFINE_UNQUOTED([TAR], ["$TAR"], [Define path to tar])
-AC_CHECK_HEADERS([float.h mcheck.h alloca.h sys/mman.h netinet/tcp.h])
+AC_CHECK_HEADERS([netinet/tcp.h])
 AC_CHECK_HEADERS([netinet/tcp_var.h], [], [],
 [#if HAVE_SYS_TYPES_H
 # include <sys/types.h>
@@ -201,18 +201,14 @@ if test x"$ac_cv_func_connect" = x"no"; then
     fi
 fi
 
-AC_CHECK_LIB(resolv, hstrerror, , , [-lnsl -lsocket])
-AC_CHECK_LIB(resolv, inet_aton, , , [-lnsl -lsocket])
-
-AC_CHECK_FUNCS([setsid flock lockf hstrerror strerror setuid setreuid])
-AC_CHECK_FUNCS([getuid geteuid mcheck wait4 wait3 waitpid setgroups getcwd])
-AC_CHECK_FUNCS([snprintf vsnprintf vasprintf asprintf getcwd getwd])
+AC_CHECK_FUNCS([flock lockf strerror setuid])
+AC_CHECK_FUNCS([getuid geteuid wait4 waitpid setgroups getcwd])
+AC_CHECK_FUNCS([snprintf])
 AC_CHECK_FUNCS([getrusage strsignal gettimeofday])
-AC_CHECK_FUNCS([getaddrinfo getnameinfo inet_ntop inet_ntoa])
-AC_CHECK_FUNCS([strndup mmap strlcpy])
+AC_CHECK_FUNCS([getnameinfo inet_ntoa])
 AC_CHECK_FUNCS([getloadavg])
 
-AC_CHECK_DECLS([snprintf, vsnprintf, vasprintf, asprintf, strndup])
+AC_CHECK_DECLS([snprintf])
 
 AC_CHECK_LIB(lzo2, lzo1x_1_compress, LZO_LDADD=-llzo2,
 	AC_MSG_ERROR([Could not find lzo2 library - please install lzo-devel]))

--- a/configure.ac
+++ b/configure.ac
@@ -177,14 +177,10 @@ if test x"$ac_cv_func_connect" = x"no"; then
     fi
 fi
 
-AC_CHECK_FUNCS([flock lockf strerror setuid])
-AC_CHECK_FUNCS([getuid geteuid wait4 waitpid setgroups getcwd])
-AC_CHECK_FUNCS([snprintf])
-AC_CHECK_FUNCS([getrusage strsignal gettimeofday])
-AC_CHECK_FUNCS([getnameinfo inet_ntoa])
+AC_CHECK_FUNCS([flock lockf])
+AC_CHECK_FUNCS([wait4 setgroups])
+AC_CHECK_FUNCS([strsignal])
 AC_CHECK_FUNCS([getloadavg])
-
-AC_CHECK_DECLS([snprintf])
 
 AC_CHECK_LIB(lzo2, lzo1x_1_compress, LZO_LDADD=-llzo2,
 	AC_MSG_ERROR([Could not find lzo2 library - please install lzo-devel]))

--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -32,9 +32,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "comm.h"
 #include "exitcode.h"

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -37,9 +37,7 @@
 #include <netdb.h>
 #include <getopt.h>
 
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -68,10 +66,6 @@
 #  include <resolv.h>
 #endif
 #include <netdb.h>
-
-#ifdef HAVE_SYS_RESOURCE_H
-#  include <sys/resource.h>
-#endif
 
 #ifndef RUSAGE_SELF
 #  define RUSAGE_SELF (0)

--- a/services/getifaddrs.h
+++ b/services/getifaddrs.h
@@ -26,9 +26,7 @@
 
 #include "config.h"
 
-#ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif
 
 #include <sys/socket.h>
 #include <net/if.h>

--- a/services/tempfile.c
+++ b/services/tempfile.c
@@ -77,16 +77,12 @@ int dcc_make_tmpnam(const char *prefix, const char *suffix, char **name_ret, int
 
     random_bits = (unsigned long) getpid() << 16;
 
-# if HAVE_GETTIMEOFDAY
     {
         struct timeval tv;
         gettimeofday(&tv, NULL);
         random_bits ^= tv.tv_usec << 16;
         random_bits ^= tv.tv_sec;
     }
-# else
-    random_bits ^= time(NULL);
-# endif
 
 #if 0
     random_bits = 0;            /* FOR TESTING */


### PR DESCRIPTION
Remove configure checks for headers and functions which are
- not used at all
- POSIX (and thus they ought to be available)
- not POSIX, but are so far used unconditionally

This series should cause no change in the supported OSes, since all the headers and functions previously checked and used continue to be handled as before.
