### PR TITLE
Avoid accidental assignments

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -175,8 +175,8 @@ static int create_native(char **args)
     if (machine_name.find("Darwin") == 0)
         is_clang = true;
     // Args[0] may be a compiler or the first extra file.
-    if (args[0] && ((!strcmp(args[0], "clang") && (is_clang = true))
-                    || (!strcmp(args[0], "gcc") && (is_clang = false)))) {
+    if (args[0] && ((!strcmp(args[0], "clang") && is_clang)
+                    || (!strcmp(args[0], "gcc") && !is_clang))) {
         extrafiles++;
     }
 


### PR DESCRIPTION
Fixes recent regression with '~/src/icecream/client/icecc
--build-native gcc' which broke icecc on non-Darwin entirely.