### PR TITLE
Fix creation of native environment for gcc

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -175,8 +175,11 @@ static int create_native(char **args)
     if (machine_name.find("Darwin") == 0)
         is_clang = true;
     // Args[0] may be a compiler or the first extra file.
-    if (args[0] && ((!strcmp(args[0], "clang") && (is_clang = true))
-                    || (!strcmp(args[0], "gcc") && (is_clang = false)))) {
+    if (args[0] && !strcmp(args[0], "clang")) {
+        is_clang = true;
+        extrafiles++;
+    } else if (args[0] && !strcmp(args[0], "gcc")) {
+        is_clang = false;
         extrafiles++;
     }
 


### PR DESCRIPTION
In 96552a293a55d15d7179285a70868f0a55c9a6ea, the default compiler for
MacOS was changed and because of that the code could no longer assume
that gcc is the true unless clang is explicitly specified. For that
reason the commit explicitly set 'is_clang' to false when 'gcc' is
requested as compiler.

However it did so inside an if expression causing the expression to
evaluate to false always and without incrementing the extrafiles
pointer. This in turn caused the rest of create_native to believe gcc
is an extra file to be added to the tarball. No such file normally
exists so the creation of a native environment failed.

Fix this issue by moving the is_clang assignments outside the if
expressions, making the code slightly longer but clearer.