### PR TITLE
[not-ready] scheduler should not assume environment is on local server

### DIFF
--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -464,10 +464,6 @@ static bool handle_local_job_done(CompileServer *cs, Msg *_m)
    platform).  */
 static string envs_match(CompileServer *cs, const Job *job)
 {
-    if (job->submitter() == cs) {
-        return cs->hostPlatform();    // it will compile itself
-    }
-
     Environments compilerVersions = cs->compilerVersions();
 
     /* Check all installed envs on the candidate CS ...  */


### PR DESCRIPTION
The problem is simple the scheduler assumes that the host the job is coming from has all the environments of the job, but in fact this is not true, in the case of a chroot the host may not have access to the environment (at least not by the paths given)
