### PR TITLE
Retrieve the physical number of cores not counting hyperthreaded cores

### DIFF
--- a/daemon/ncpus.c
+++ b/daemon/ncpus.c
@@ -115,10 +115,8 @@ int dcc_ncpus(int *ncpus)
 {
     int mib[2];
     size_t len = sizeof(*ncpus);
-    mib[0] = CTL_HW;
-    mib[1] = HW_NCPU;
 
-    if (sysctl(mib, 2, ncpus, &len, NULL, 0) == 0) {
+    if (sysctlbyname("hw.physicalcpu", ncpus, &len, NULL, 0) == 0) {
         return 0;
     }
 


### PR DESCRIPTION
Modern MacPro workstations have 12 physical cores which are hyperthreaded. The current npcus logic returns 24 in this case which is a bit high if you are going for decent load balancing. This change will only report physical CPUs which makes the whole network run better.