### PR TITLE
[not-ready] Fix relative paths to toolchain files

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -27,6 +27,29 @@ is_contained ()
   esac
 }
 
+# Equivalent to Linux readlink -f command
+resolve_path ()
+{
+    TARGET_FILE=$1
+
+    cd `dirname $TARGET_FILE`
+    TARGET_FILE=`basename $TARGET_FILE`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+        TARGET_FILE=`readlink $TARGET_FILE`
+        cd `dirname $TARGET_FILE`
+        TARGET_FILE=`basename $TARGET_FILE`
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT=$PHYS_DIR/$TARGET_FILE
+    echo $RESULT
+}
+
 add_file ()
 {
   local name="$1"
@@ -143,6 +166,9 @@ search_addfile()
             # Replacing relative path by abs path because the tar command
             # used to create the tarball file doesn't work well with
             # relative path as installdir.
+
+            compiler=$(resolve_path $compiler)
+            abs_installdir=$(resolve_path $abs_installdir)
 
             compiler_basedir=$(abs_path ${compiler%/*/*})
             file_installdir=${abs_installdir/$compiler_basedir/"/usr"}


### PR DESCRIPTION
Use 'readlink -e' to follow the compiler and toolchain file to their
fully resolved location without which relative paths generated will
be incorrect especially when the compiler itself is pointed by a
symbolic link.
