### PR TITLE
Fix out of tree build

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -24,7 +24,8 @@ noinst_HEADERS = \
 	util.h
 AM_CPPFLAGS = \
 	-DPLIBDIR=\"$(pkglibexecdir)\" \
-	-I$(top_srcdir)/services
+	-I$(top_srcdir)/services \
+	-I$(top_srcdir)/
 
 EXTRA_DIST = icecc-create-env
 


### PR DESCRIPTION
 - Add -I/ to client/Makefile.am AM_CPPFLAGS since
   remote.cpp need include "services/util.h"