### PR TITLE
implement -gsplit-dwarf (dwarf fission) support

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -301,6 +301,8 @@ for extrafile in $extrafiles; do
     add_file $extrafile
 done
 
+add_file /usr/bin/objcopy
+
 if test "$is_darwin" = 1; then
     # add dynamic linker
     add_file /usr/lib/dyld

--- a/client/local.cpp
+++ b/client/local.cpp
@@ -229,6 +229,10 @@ int build_local(CompileJob &job, MsgChannel *local_daemon, struct rusage *used)
     arguments.push_back(compiler_name);
     appendList(arguments, job.allFlags());
 
+    if (job.dwarfFissionEnabled()) {
+        arguments.push_back("-gsplit-dwarf");
+    }
+
     if (!job.inputFile().empty()) {
         arguments.push_back(job.inputFile());
     }

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -176,7 +176,7 @@ static int create_native(char **args)
         is_clang = true;
     // Args[0] may be a compiler or the first extra file.
     if (args[0] && ((!strcmp(args[0], "clang") && (is_clang = true))
-                    || (!strcmp(args[0], "gcc") && (is_clang = false)))) {
+                    || (!strcmp(args[0], "gcc") && !(is_clang = false)))) {
         extrafiles++;
     }
 

--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -573,12 +573,17 @@ static int build_remote_int(CompileJob &job, UseCSMsg *usecs, MsgChannel *local_
             }
         }
 
+        bool have_dwo_file = crmsg->have_dwo_file;
         delete crmsg;
 
         assert(!job.outputFile().empty());
 
         if (status == 0) {
             receive_file(job.outputFile(), cserver);
+            if (have_dwo_file) {
+                string dwo_output = job.outputFile().substr(0, job.outputFile().find_last_of('.')) + ".dwo";
+                receive_file(dwo_output, cserver);
+            }
         }
 
     } catch (int x) {
@@ -714,6 +719,7 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
     srand(time(0) + getpid());
 
     int torepeat = 1;
+    bool has_split_dwarf = job.dwarfFissionEnabled();
 
     // older compilers do not support the options we need to make it reproducible
 #if defined(__GNUC__) && ( ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 3) ) || (__GNUC__ >=4) )
@@ -902,6 +908,10 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
                                     << " and " << umsgs[0]->hostname << " compiled with exit code "
                                     << exit_codes[0] << " - aborting!\n";
                         ::unlink(jobs[0].outputFile().c_str());
+                        if (has_split_dwarf) {
+                            string dwo_file = jobs[0].outputFile().substr(0, jobs[0].outputFile().find_last_of('.')) + ".dwo";
+                            ::unlink(dwo_file.c_str());
+                        }
                         exit_codes[0] = -1; // overwrite
                         break;
                     }
@@ -917,19 +927,35 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
                         rename(jobs[0].outputFile().c_str(),
                                (jobs[0].outputFile() + ".caught").c_str());
                         rename(preproc, (string(preproc) + ".caught").c_str());
+                        if (has_split_dwarf) {
+                            string dwo_file = jobs[0].outputFile().substr(0, jobs[0].outputFile().find_last_of('.')) + ".dwo";
+                            rename(dwo_file.c_str(), (dwo_file + ".caught").c_str());
+                        }
                         exit_codes[0] = -1; // overwrite
                         break;
                     }
                 }
 
                 ::unlink(jobs[i].outputFile().c_str());
+                if (has_split_dwarf) {
+                    string dwo_file = jobs[i].outputFile().substr(0, jobs[i].outputFile().find_last_of('.')) + ".dwo";
+                    ::unlink(dwo_file.c_str());
+                }
                 delete umsgs[i];
             }
         } else {
             ::unlink(jobs[0].outputFile().c_str());
+            if (has_split_dwarf) {
+                string dwo_file = jobs[0].outputFile().substr(0, jobs[0].outputFile().find_last_of('.')) + ".dwo";
+                ::unlink(dwo_file.c_str());
+            }
 
             for (int i = 1; i < torepeat; i++) {
                 ::unlink(jobs[i].outputFile().c_str());
+                if (has_split_dwarf) {
+                    string dwo_file = jobs[i].outputFile().substr(0, jobs[i].outputFile().find_last_of('.')) + ".dwo";
+                    ::unlink(dwo_file.c_str());
+                }
                 delete umsgs[i];
             }
         }

--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -686,8 +686,12 @@ maybe_build_local(MsgChannel *local_daemon, UseCSMsg *usecs, CompileJob &job,
 
         struct stat st;
 
+        msg.out_uncompressed = 0;
         if (!stat(job.outputFile().c_str(), &st)) {
-            msg.out_uncompressed = st.st_size;
+            msg.out_uncompressed += st.st_size;
+        }
+        if (!stat((job.outputFile().substr(0, job.outputFile().find_last_of('.')) + ".dwo").c_str(), &st)) {
+            msg.out_uncompressed += st.st_size;
         }
 
         msg.user_msec = ru.ru_utime.tv_sec * 1000 + ru.ru_utime.tv_usec / 1000;

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -6,7 +6,8 @@ iceccd_SOURCES = \
 	serve.cpp \
 	workit.cpp \
 	environment.cpp \
-	load.cpp
+	load.cpp \
+	file_util.cpp
 
 iceccd_LDADD = \
 	../services/libicecc.la \
@@ -21,4 +22,5 @@ noinst_HEADERS = \
 	load.h \
 	ncpus.h \
 	serve.h \
-	workit.h
+	workit.h \
+	file_util.h

--- a/daemon/file_util.cpp
+++ b/daemon/file_util.cpp
@@ -1,0 +1,156 @@
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <dirent.h>
+#include <sys/stat.h>
+
+#include "file_util.h"
+
+
+using namespace std;
+
+/**
+ * Adapted from an answer by "Evan Teran" from this stack overflow question:
+ * http://stackoverflow.com/questions/236129/split-a-string-in-c
+ */
+vector<string> split(const string &s, char delim) {
+    vector<string> elems;
+    stringstream ss(s);
+    string item;
+    while (getline(ss, item, delim)) {
+        if (!item.empty()) {
+            elems.push_back(item);
+        }
+    }
+    return elems;
+}
+
+/**
+ * Adapted from an answer by "dash-tom-bang" from this stack overflow question:
+ * http://stackoverflow.com/questions/5772992/get-relative-path-from-two-absolute-paths
+ */
+string get_relative_path(const string &to, const string &from) {
+    vector<string> to_dirs = split(to, '/');
+    vector<string> from_dirs = split(from, '/');
+
+    string output;
+    output.reserve(to.size());
+
+    vector<string>::const_iterator to_it = to_dirs.begin(),
+                                   to_end = to_dirs.end(),
+                                   from_it = from_dirs.begin(),
+                                   from_end = from_dirs.end();
+
+    while ((to_it != to_end) && (from_it != from_end) && *to_it == *from_it) {
+         ++to_it;
+         ++from_it;
+    }
+
+    while (from_it != from_end) {
+        output += "../";
+        ++from_it;
+    }
+
+    while (to_it != to_end) {
+        output += *to_it;
+        ++to_it;
+
+        if (to_it != to_end) {
+            output += "/";
+        }
+    }
+
+    return output;
+}
+
+/**
+ * Adapted from an answer by "Mark" from this stack overflow question:
+ * http://stackoverflow.com/questions/675039/how-can-i-create-directory-tree-in-c-linux
+ */
+bool mkpath(const string &path) {
+    bool success = false;
+    int ret = mkdir(path.c_str(), 0775);
+    if(ret == -1) {
+        switch(errno) {
+            case ENOENT:
+                if(mkpath(path.substr(0, path.find_last_of('/'))))
+                    success = 0 == mkdir(path.c_str(), 0775);
+                else
+                    success = false;
+                break;
+            case EEXIST:
+                success = true;
+                break;
+            default:
+                success = false;
+                break;
+        }
+    }
+    else {
+        success = true;
+    }
+
+    return success;
+}
+
+/**
+ * Adapted from an answer by "asveikau" from this stack overflow question:
+ * http://stackoverflow.com/questions/2256945/removing-a-non-empty-directory-programmatically-in-c-or-c
+ */
+bool rmpath(const char* path) {
+    DIR *d = opendir(path);
+    size_t path_len = strlen(path);
+    int r = -1;
+
+    if (d) {
+        struct dirent *p;
+
+        r = 0;
+
+        while (!r && (p=readdir(d))) {
+            int r2 = -1;
+            char *buf;
+            size_t len;
+
+            /* Skip the names "." and ".." as we don't want to recurse on them. */
+            if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, "..")) {
+                continue;
+            }
+
+            len = path_len + strlen(p->d_name) + 2;
+            buf = (char*)malloc(len);
+
+            if (buf) {
+                struct stat statbuf;
+
+                snprintf(buf, len, "%s/%s", path, p->d_name);
+
+                if (!stat(buf, &statbuf)) {
+                    if (S_ISDIR(statbuf.st_mode)) {
+                        r2 = rmpath(buf);
+                    }
+                    else {
+                        r2 = unlink(buf);
+                    }
+                }
+
+                free(buf);
+            }
+
+            r = r2;
+        }
+
+        closedir(d);
+    }
+
+    if (!r) {
+        r = rmdir(path);
+    }
+
+    return r;
+}

--- a/daemon/file_util.cpp
+++ b/daemon/file_util.cpp
@@ -69,6 +69,53 @@ string get_relative_path(const string &to, const string &from) {
 }
 
 /**
+ * Returns a string without '..' and '.'
+ *
+ * Preconditions:  path must be an absolute path
+ * Postconditions: if path is empty or not an absolute path, return original
+ *                 path, otherwise, return path after resolving '..' and '.'
+ */
+string get_canonicalized_path(const string &path) {
+    if (path.empty() || path[0] != '/') {
+        return path;
+    }
+
+    vector<string> parts = split(path, '/');
+    vector<string> canonicalized_path;
+
+    vector<string>::const_iterator parts_it = parts.begin(),
+                                   parts_end = parts.end();
+
+    while (parts_it != parts_end) {
+        if (*parts_it == ".." && !canonicalized_path.empty()) {
+            canonicalized_path.pop_back();
+        }
+        else if (*parts_it != ".") {
+            canonicalized_path.push_back(*parts_it);
+        }
+
+        ++parts_it;
+    }
+
+    vector<string>::const_iterator path_it = canonicalized_path.begin(),
+                                   path_end = canonicalized_path.end();
+
+    string output;
+    output.reserve(path.size());
+    output += "/";
+    while (path_it != path_end) {
+        output += *path_it;
+
+        ++path_it;
+        if (path_it != path_end) {
+            output += "/";
+        }
+    }
+
+    return output;
+}
+
+/**
  * Adapted from an answer by "Mark" from this stack overflow question:
  * http://stackoverflow.com/questions/675039/how-can-i-create-directory-tree-in-c-linux
  */

--- a/daemon/file_util.h
+++ b/daemon/file_util.h
@@ -1,0 +1,33 @@
+/* -*- mode: C++; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 99; -*- */
+/* vim: set ts=4 sw=4 et tw=99:  */
+/*
+    This file is part of Icecream.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef ICECREAM_FILE_UTIL_H
+#define ICECREAM_FILE_UTIL_H
+
+#include <vector>
+#include <string>
+
+std::vector<std::string> split(const std::string &s, char delim);
+std::string get_relative_path(const std::string &to, const std::string &from);
+bool mkpath(const std::string &path);
+bool rmpath(const char* path);
+
+#endif
+

--- a/daemon/file_util.h
+++ b/daemon/file_util.h
@@ -26,6 +26,7 @@
 
 std::vector<std::string> split(const std::string &s, char delim);
 std::string get_relative_path(const std::string &to, const std::string &from);
+std::string get_canonicalized_path(const std::string &path);
 bool mkpath(const std::string &path);
 bool rmpath(const char* path);
 

--- a/daemon/serve.cpp
+++ b/daemon/serve.cpp
@@ -283,7 +283,10 @@ int handle_connection(const string &basedir, CompileJob *job,
         struct stat st;
 
         if (!stat(obj_file.c_str(), &st)) {
-            job_stat[JobStatistics::out_uncompressed] = st.st_size;
+            job_stat[JobStatistics::out_uncompressed] += st.st_size;
+        }
+        if (!stat(dwo_file.c_str(), &st)) {
+            job_stat[JobStatistics::out_uncompressed] += st.st_size;
         }
 
         /* wake up parent and tell him that compile finished */

--- a/daemon/serve.cpp
+++ b/daemon/serve.cpp
@@ -129,7 +129,6 @@ static void write_output_file( const string& file, MsgChannel* client )
     }
 }
 
-
 /**
  * Read a request, run the compiler, and send a response.
  **/
@@ -222,13 +221,13 @@ int handle_connection(const string &basedir, CompileJob *job,
             // letting us set up a "chroot"ed environment inside the build folder and letting
             // us set up the paths to mimic the client system
 
-            string file_name;
             string job_output_file = job->outputFile();
             string job_working_dir = job->workingDirectory();
-            string job_output_file_dir = job_output_file.substr(0, job_output_file.find_last_of('/'));
 
             size_t slash_index = job_output_file.find_last_of('/');
+            string file_dir, file_name;
             if (slash_index != string::npos) {
+                file_dir = job_output_file.substr(0, job_output_file.find_last_of('/'));
                 file_name = job_output_file.substr(slash_index+1);
             }
             else {
@@ -236,13 +235,13 @@ int handle_connection(const string &basedir, CompileJob *job,
             }
 
             string output_dir, relative_file_path;
-            if (job_output_file_dir[0] == '/') { // output dir is absolute, convert to relative
-                relative_file_path = get_relative_path(tmp_path + job_output_file, tmp_path + job_working_dir);
-                output_dir = tmp_path + job_output_file_dir;
+            if (!file_dir.empty() && file_dir[0] == '/') { // output dir is absolute, convert to relative
+                relative_file_path = get_relative_path(tmp_path + get_canonicalized_path(job_output_file), tmp_path + get_canonicalized_path(job_working_dir));
+                output_dir = tmp_path + get_canonicalized_path(file_dir);
             }
             else { // output file is already relative
                 relative_file_path = job_output_file;
-                output_dir = tmp_path + job_working_dir + '/' + job_output_file_dir; // need the path separator since this is relative
+                output_dir = tmp_path + get_canonicalized_path(job_working_dir + '/' + file_dir); // need the path separator since this is relative
             }
 
             if (!mkpath(output_dir)) {

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -59,7 +59,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string>
-#include <sys/stat.h>
 
 #include "comm.h"
 #include "platform.h"

--- a/daemon/workit.h
+++ b/daemon/workit.h
@@ -51,8 +51,8 @@ enum job_stat_fields { in_compressed, in_uncompressed, out_uncompressed, exit_co
                      };
 }
 
-extern int work_it(CompileJob &j, unsigned int job_stats[], MsgChannel *client,
-                   CompileResultMsg &msg, const std::string &outfilename,
+extern int work_it(CompileJob &j, unsigned int job_stats[], MsgChannel *client, CompileResultMsg &msg,
+                   const std::string &tmp_root, const std::string &build_path, const std::string &file_name,
                    unsigned long int mem_limit, int client_fd, int job_in_fd);
 
 #endif

--- a/services/comm.cpp
+++ b/services/comm.cpp
@@ -1607,6 +1607,14 @@ void CompileFileMsg::fill_from_channel(MsgChannel *c)
         job->setInputFile(inputFile);
         job->setWorkingDirectory(workingDirectory);
     }
+    if (IS_PROTOCOL_35(c)) {
+        string outputFile;
+        uint32_t dwarfFissionEnabled = 0;
+        *c >> outputFile;
+        *c >> dwarfFissionEnabled;
+        job->setOutputFile(outputFile);
+        job->setDwarfFissionEnabled(dwarfFissionEnabled);
+    }
 }
 
 void CompileFileMsg::send_to_channel(MsgChannel *c) const
@@ -1638,6 +1646,10 @@ void CompileFileMsg::send_to_channel(MsgChannel *c) const
     if( IS_PROTOCOL_34(c)) {
         *c << job->inputFile();
         *c << job->workingDirectory();
+    }
+    if (IS_PROTOCOL_35(c)) {
+        *c << job->outputFile();
+        *c << (uint32_t) job->dwarfFissionEnabled();
     }
 }
 
@@ -1698,6 +1710,11 @@ void CompileResultMsg::fill_from_channel(MsgChannel *c)
     uint32_t was = 0;
     *c >> was;
     was_out_of_memory = was;
+    if (IS_PROTOCOL_35(c)) {
+        uint32_t dwo = 0;
+        *c >> dwo;
+        have_dwo_file = dwo;
+    }
 }
 
 void CompileResultMsg::send_to_channel(MsgChannel *c) const
@@ -1707,6 +1724,9 @@ void CompileResultMsg::send_to_channel(MsgChannel *c) const
     *c << out;
     *c << status;
     *c << (uint32_t) was_out_of_memory;
+    if (IS_PROTOCOL_35(c)) {
+        *c << (uint32_t) have_dwo_file;
+    }
 }
 
 void JobBeginMsg::fill_from_channel(MsgChannel *c)

--- a/services/comm.h
+++ b/services/comm.h
@@ -36,7 +36,7 @@
 #include "job.h"
 
 // if you increase the PROTOCOL_VERSION, add a macro below and use that
-#define PROTOCOL_VERSION 34
+#define PROTOCOL_VERSION 35
 // if you increase the MIN_PROTOCOL_VERSION, comment out macros below and clean up the code
 #define MIN_PROTOCOL_VERSION 21
 
@@ -59,6 +59,7 @@
 #define IS_PROTOCOL_32(c) ((c)->protocol >= 32)
 #define IS_PROTOCOL_33(c) ((c)->protocol >= 33)
 #define IS_PROTOCOL_34(c) ((c)->protocol >= 34)
+#define IS_PROTOCOL_35(c) ((c)->protocol >= 35)
 
 enum MsgType {
     // so far unknown
@@ -502,7 +503,8 @@ public:
     CompileResultMsg()
         : Msg(M_COMPILE_RESULT)
         , status(0)
-        , was_out_of_memory(false) {}
+        , was_out_of_memory(false)
+        , have_dwo_file(false) {}
 
     virtual void fill_from_channel(MsgChannel *c);
     virtual void send_to_channel(MsgChannel *c) const;
@@ -511,6 +513,7 @@ public:
     std::string out;
     std::string err;
     bool was_out_of_memory;
+    bool have_dwo_file;
 };
 
 class JobBeginMsg : public Msg

--- a/services/job.h
+++ b/services/job.h
@@ -64,6 +64,7 @@ public:
 
     CompileJob()
         : m_id(0)
+        , m_dwarf_fission(false)
     {
         setTargetPlatform();
     }
@@ -139,6 +140,16 @@ public:
         return m_output_file;
     }
 
+    void setDwarfFissionEnabled(bool flag)
+    {
+        m_dwarf_fission = flag;
+    }
+
+    bool dwarfFissionEnabled() const
+    {
+        return m_dwarf_fission;
+    }
+
     void setWorkingDirectory(const std::string& dir)
     {
         m_working_directory = dir;
@@ -187,6 +198,7 @@ private:
     std::string m_input_file, m_output_file;
     std::string m_working_directory;
     std::string m_target_platform;
+    bool m_dwarf_fission;
 };
 
 inline void appendList(std::list<std::string> &list, const std::list<std::string> &toadd)

--- a/services/tempfile.h
+++ b/services/tempfile.h
@@ -27,6 +27,7 @@ extern "C" {
     int dcc_make_tmpnam(const char *prefix,
                         const char *suffix,
                         char **name_ret, int relative);
+    int dcc_make_tmpdir(char **name_ret);
 
 #ifdef __cplusplus
 }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -253,7 +253,7 @@ run_ice()
         shift
     fi
     split_dwarf=
-    if test "$1" = "yes"; then
+    if test "$1" = "split_dwarf"; then
         split_dwarf=$(echo $output | sed 's/\.[^.]*//g').dwo
         shift
     fi
@@ -261,7 +261,6 @@ run_ice()
     reset_logs local "$@"
     echo Running: "$@"
     ICECC_TEST_SOCKET="$testdir"/socket-localice ICECC_TEST_REMOTEBUILD=1 ICECC_PREFERRED_HOST=localice ICECC_DEBUG=debug ICECC_LOGFILE="$testdir"/icecc.log $valgrind "$prefix"/bin/icecc "$@" 2>"$testdir"/stderr.localice
-    #sleep 400
 
     localice_exit=$?
     if test -n "$output"; then
@@ -352,14 +351,19 @@ run_ice()
             exit 2
         fi
     fi
+
+    remove_debug_info="s/DW_AT_\(GNU_dwo_\(id\|name\)\|comp_dir\|producer\|linkage_name\|name\).*//g"
     if test -n "$output"; then
-        if ! diff -q "$output".localice "$output"; then
+        readelf -wlLiaprmfFoRt "$output" | sed -e $remove_debug_info > "$output".readelf.txt || cp "$output" "$output".readelf.txt
+        readelf -wlLiaprmfFoRt "$output".localice | sed -e $remove_debug_info > "$output".local.readelf.txt || cp "$output" "$output".local.readelf.txt
+        if ! diff -q "$output".local.readelf.txt "$output".readelf.txt; then
             echo "Output mismatch ($output.localice)"
             stop_ice 0
             exit 2
         fi
         if test -z "$chroot_disabled"; then
-            if ! diff -q "$output".remoteice "$output"; then
+            readelf -wlLiaprmfFoRt "$output".remoteice | sed -e "$remove_debug_info" > "$output".remote.readelf.txt || cp "$output" "$output".remote.readelf.txt
+            if ! diff -q "$output".remote.readelf.txt "$output".readelf.txt; then
                 echo "Output mismatch ($output.remoteice)"
                 stop_ice 0
                 exit 2
@@ -367,13 +371,16 @@ run_ice()
         fi
     fi
     if test -n "$split_dwarf"; then
-        if ! diff -q "$split_dwarf".localice "$split_dwarf"; then
+        readelf -wlLiaprmfFoRt "$split_dwarf" | sed -e $remove_debug_info > "$split_dwarf".readelf.txt || cp "$split_dwarf" "$split_dwarf".readelf.txt
+        readelf -wlLiaprmfFoRt "$split_dwarf".localice | sed -e $remove_debug_info > "$split_dwarf".local.readelf.txt || cp "$split_dwarf" "$split_dwarf".local.readelf.txt
+        if ! diff -q "$split_dwarf".local.readelf.txt "$split_dwarf".readelf.txt; then
             echo "Output DWO mismatch ($split_dwarf.localice)"
             stop_ice 0
             exit 2
         fi
         if test -z "$chroot_disabled"; then
-            if ! diff -q "$split_dwarf".remoteice "$split_dwarf"; then
+            readelf -wlLiaprmfFoRt "$split_dwarf".remoteice | sed -e "$remove_debug_info" > "$split_dwarf".remote.readelf.txt || cp "$split_dwarf" "$split_dwarf".remote.readelf.txt
+            if ! diff -q "$split_dwarf".remote.readelf.txt "$split_dwarf".readelf.txt; then
                 echo "Output DWO mismatch ($split_dwarf.remoteice)"
                 stop_ice 0
                 exit 2
@@ -388,10 +395,10 @@ run_ice()
         echo
     fi
     if test -n "$output"; then
-        rm -f "$output" "$output".localice "$output".remoteice
+        rm -f "$output" "$output".localice "$output".remoteice "$output".readelf.txt "$output".local.readelf.txt "$output".remote.readelf.txt
     fi
     if test -n "$split_dwarf"; then
-        rm -f "$split_dwarf" "$split_dwarf".localice "$split_dwarf".remoteice
+        rm -f "$split_dwarf" "$split_dwarf".localice "$split_dwarf".remoteice "$split_dwarf".readelf.txt "$split_dwarf".local.readelf.txt "$split_dwarf".remote.readelf.txt
     fi
     rm -f "$testdir"/stderr "$testdir"/stderr.localice "$testdir"/stderr.remoteice
 }
@@ -410,7 +417,7 @@ make_test()
     echo Running make test $run_number.
     reset_logs remote "make test $run_number"
     make -f Makefile.test OUTDIR="$testdir" clean -s
-    PATH="$prefix"/lib/icecc/bin:/usr/local/bin:/usr/bin:/bin ICECC_TEST_SOCKET="$testdir"/socket-localice ICECC_TEST_REMOTEBUILD=1 ICECC_DEBUG=debug ICECC_LOGFILE="$testdir"/icecc.log make -f Makefile.test OUTDIR="$testdir" -j10 -s 2>>"$testdir"/stderr.log
+    PATH="$prefix"/libexec/icecc/bin:/usr/local/bin:/usr/bin:/bin ICECC_TEST_SOCKET="$testdir"/socket-localice ICECC_TEST_REMOTEBUILD=1 ICECC_DEBUG=debug ICECC_LOGFILE="$testdir"/icecc.log make -f Makefile.test OUTDIR="$testdir" -j10 -s 2>>"$testdir"/stderr.log
     if test $? -ne 0 -o ! -x "$testdir"/maketest; then
         echo Make test $run_number failed.
         stop_ice 0
@@ -604,7 +611,7 @@ debug_test()
         stop_ice 0
         exit 2
     fi
-    gdb -nx -batch -x debug-gdb.txt "$testdir"/debug-remote >"$testdir"/debug-stdout-remote.txt 2>/dev/null
+    gdb -nx -batch -x debug-gdb.txt "$testdir"/debug-remote >"$testdir"/debug-stdout-remote.txt  2>/dev/null
     if ! grep -A 1000 "$debugstart" "$testdir"/debug-stdout-remote.txt >"$testdir"/debug-output-remote.txt ; then
         echo "Debug check failed (remote)."
         stop_ice 0
@@ -612,7 +619,8 @@ debug_test()
     fi
     # gcc-4.8+ has -grecord-gcc-switches, which makes the .o differ because of the extra flags the daemon adds,
     # this changes DW_AT_producer and also offsets
-    readelf -wlLiaprmfFoRt "$testdir"/debug-remote.o | sed 's/offset: 0x[0-9a-fA-F]*//g' | sed 's/[ ]*-fpreprocessed.*$/\t/g' > "$testdir"/readelf-remote.txt
+    remove_debug_info="s/DW_AT_\(GNU_dwo_\(id\|name\)\|comp_dir\|producer\|linkage_name\|name\).*//g"
+    readelf -wlLiaprmfFoRt "$testdir"/debug-remote.o | sed -e 's/offset: 0x[0-9a-fA-F]*//g' -e 's/[ ]*--param ggc-min-expand.*heapsize\=[0-9]\+//g' -e $remove_debug_info > "$testdir"/readelf-remote.txt
 
     $cmd -o "$testdir"/debug-local.o 2>>"$testdir"/stderr.log
     if test $? -ne 0; then
@@ -632,7 +640,7 @@ debug_test()
         stop_ice 0
         exit 2
     fi
-    readelf -wlLiaprmfFoRt "$testdir"/debug-local.o | sed 's/offset: 0x[0-9a-fA-F]*//g' > "$testdir"/readelf-local.txt
+    readelf -wlLiaprmfFoRt "$testdir"/debug-local.o | sed -e 's/offset: 0x[0-9a-fA-F]*//g' -e $remove_debug_info > "$testdir"/readelf-local.txt
 
     if ! diff -q "$testdir"/debug-output-local.txt "$testdir"/debug-output-remote.txt ; then
         echo Gdb output different.
@@ -766,7 +774,7 @@ check_logs_for_generic_errors
 echo Starting icecream successful.
 echo
 
-run_ice "$testdir/plain.o" "remote" 0 "yes" $GXX -Wall -gsplit-dwarf -Werror -c plain.cpp -o "$testdir/"plain.o
+run_ice "$testdir/plain.o" "remote" 0 "split_dwarf" $GXX -Wall -Werror -gsplit-dwarf -g -c plain.cpp -o "$testdir/"plain.o
 run_ice "$testdir/plain.o" "remote" 0 $GXX -Wall -Werror -c plain.cpp -o "$testdir/"plain.o
 
 if test -z "$chroot_disabled"; then
@@ -774,12 +782,14 @@ if test -z "$chroot_disabled"; then
     make_test 2
 fi
 
+run_ice "$testdir/plain.o" "remote" 0 "split_dwarf" $GCC -Wall -Werror -gsplit-dwarf -c plain.c -o "$testdir/"plain.o
 run_ice "$testdir/plain.o" "remote" 0 $GCC -Wall -Werror -c plain.c -o "$testdir/"plain.o
 run_ice "$testdir/plain.o" "remote" 0 $GXX -Wall -Werror -c plain.cpp -O2 -o "$testdir/"plain.o
 run_ice "$testdir/plain.ii" "local" 0 $GXX -Wall -Werror -E plain.cpp -o "$testdir/"plain.ii
 run_ice "$testdir/includes.o" "remote" 0 $GXX -Wall -Werror -c includes.cpp -o "$testdir"/includes.o
 run_ice "$testdir/plain.o" "local" 0 $GXX -Wall -Werror -c plain.cpp -mtune=native -o "$testdir"/plain.o
 run_ice "$testdir/plain.o" "remote" 0 $GCC -Wall -Werror -x c++ -c plain -o "$testdir"/plain.o
+run_ice "" "remote" 1 "split_dwarf" $GXX -gsplit-dwarf -c nonexistent.cpp
 run_ice "" "remote" 1 $GXX -c nonexistent.cpp
 run_ice "" "local" 0 /bin/true
 
@@ -801,7 +811,9 @@ fi
 if command -v gdb >/dev/null; then
     if command -v readelf >/dev/null; then
         debug_test "$GXX -c -g debug.cpp" "Temporary breakpoint 1, main () at debug.cpp:8"
+        debug_test "$GXX -c -g debug.cpp -gsplit-dwarf" "Temporary breakpoint 1, main () at debug.cpp:8"
         debug_test "$GXX -c -g `pwd`/debug/debug2.cpp" "Temporary breakpoint 1, main () at `pwd`/debug/debug2.cpp:8"
+        debug_test "$GXX -c -g `pwd`/debug/debug2.cpp -gsplit-dwarf" "Temporary breakpoint 1, main () at `pwd`/debug/debug2.cpp:8"
     fi
 else
     skipped_tests="$skipped_tests debug"
@@ -839,7 +851,9 @@ if test -x $CLANGXX; then
     if command -v gdb >/dev/null; then
         if command -v readelf >/dev/null; then
             debug_test "$CLANGXX -c -g debug.cpp" "Temporary breakpoint 1, main () at debug.cpp:8"
+            debug_test "$CLANGXX -c -g debug.cpp -gsplit-dwarf" "Temporary breakpoint 1, main () at debug.cpp:8"
             debug_test "$CLANGXX -c -g `pwd`/debug/debug2.cpp" "Temporary breakpoint 1, main () at `pwd`/debug/debug2.cpp:8"
+            debug_test "$CLANGXX -c -g `pwd`/debug/debug2.cpp -gsplit-dwarf" "Temporary breakpoint 1, main () at `pwd`/debug/debug2.cpp:8"
         fi
     fi
 


### PR DESCRIPTION
A discussion about the possibility of `-gsplit-dwarf` support feature request is in #86. For more details about the functionality, please see https://gcc.gnu.org/wiki/DebugFission.

This pull request adds full distributed compilation support when using the `-gsplit-dwarf` flag for both gcc and clang.

There is an oddity with how the compilers embed the `.dwo` file path information into the object file, and is based on the specified path to the output file on the invoked command line. Some utility methods (shamelessly adapted from various Stack Overflow discussions) aids path manipulation without `boost::filesystem`. These path manipulation techniques allow the daemon to recreate the directory structure present on the client, thus tricking the compiler into embedding `.dwo` path information that will match what the client's machine expects.

Tests have been added, though I had to resort to comparing `readelf` output whilst ignoring some debugging specific information since certain tags (`DW_AT_GNU_dwo_id`, for instance) are different on each run. `DW_AT_GNU_dwo_name` and `DW_AT_comp_dir` will be slightly different based on whether it was compiled remotely or locally, as well, since the path manipulation trick is not necessary for local builds.