### PR TITLE
Fix building with precompiled headers.

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -319,8 +319,9 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                     if (dot_index != string::npos) {
                         string ext = p.substr(dot_index + 1);
 
-                        if (ext[0] != 'h' && ext[0] != 'H' && access(p.c_str(), R_OK)
-                            && access((p + ".gch").c_str(), R_OK)) {
+                        if (ext[0] != 'h' && ext[0] != 'H'
+                            && (access(p.c_str(), R_OK)
+                                || access((p + ".gch").c_str(), R_OK))) {
                             log_info() << "include file or gch file for argument " << a << " " << p
                                        << " missing, building locally" << endl;
                             always_local = true;


### PR DESCRIPTION
This commit tweaks the handling of precompiled headers to fix building
Qt 5.5 (other versions probably also affected).

The command line is something like:

    $(CXX) -c -include .pch/Qt5WebKitWidgets <more stuff>

On disk, the precompiled headers are in a directory called
`.pch/Qt5WebKitWidgets.gch`.  The logic in icecream is a bit too
strict as it checks for the existence of both paths:

    .pch/Qt5WebKitWidgets
    .pch/Qt5WebKitWidgets.gch

The change here is to check for either of these directories. The
reason for the check for the path without "gch" in it is for
handling header files.

Signed-off-by: tombailo <tom_bailey@btinternet.com>