### PR TITLE
Make --save-temps force local building

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -248,6 +248,7 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                        || !strcmp(a, "-fprofile-generate")
                        || !strcmp(a, "-fprofile-use")
                        || !strcmp(a, "-save-temps")
+                       || !strcmp(a, "--save-temps")
                        || !strcmp(a, "-fbranch-probabilities")) {
                 log_info() << "compiler will emit profile info (argument " << a << "); building locally" << endl;
                 always_local = true;


### PR DESCRIPTION
--save-temps is alias of -save-temps, but some build system will use this one, such as gcc