### PR TITLE
allow execution of local jobs when daemon's max_jobs is set to 0

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -1210,7 +1210,8 @@ bool Daemon::handle_job_done(Client *cl, JobDoneMsg *m)
 
 void Daemon::handle_old_request()
 {
-    while ((current_kids + clients.active_processes) < max_kids) {
+    while ((current_kids + clients.active_processes) < max_kids ||
+           max_kids == 0) {
 
         Client *client = clients.get_earliest_client(Client::LINKJOB);
 

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -590,6 +590,11 @@ static CompileServer *pick_server(Job *job)
             continue;
         }
 
+        // Ignore ineligible servers
+        if (!cs->is_eligible(job)) {
+            trace() << cs->nodeName() << " not eligible" << endl;
+            continue;
+        }
         // incompatible architecture or busy installing
         if (!cs->can_install(job).size()) {
 #if DEBUG_SCHEDULER > 2


### PR DESCRIPTION
Starting the daemon with '-m 0' should allow linking to happen locally, but all compile jobs should be executed remotely. Before the compilation process would hang when the scheduler would assign a job for the local daemon with max_jobs set to 0 and the job would never get executed.
