### PR TITLE
Allow specyfing an alternate remote name in iceccd

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,13 @@ problems configuring broadcast. So you might need the -s option for the
 daemon in any case there. If the monitor can't find the scheduler, use
 USE\_SCHEDULER=\<host\> icemon (or send me a patch :)
 
+Note: If there is NAT between a daemon and the scheduler, you may experience
+failures when occasionally jobs bounce back to be compiled on the local daemon
+that issued the compile. You may try the --extra-name option on these daemons
+if you know ahead of time what is the external IP as seen by the scheduler,
+for example in a virtualized setup with 1-1 NAT floating IPs that a startup
+script can obtain, but that are not visible in normal networking tools.
+
 I use distcc, why should I change?
 -------------------------------------------------------------------------------------------------------------------
 

--- a/doc/man-iceccd.1.xml
+++ b/doc/man-iceccd.1.xml
@@ -35,6 +35,7 @@
 <arg>-b <replaceable>env-basedir</replaceable></arg>
 <arg>--cache-limit <replaceable>MB</replaceable></arg>
 <arg>-d</arg>
+<arg>--extra-name <replaceable>name</replaceable></arg>
 <arg>-l <replaceable>log-file</replaceable></arg>
 <arg>-m <replaceable>max-processes</replaceable></arg>
 <arg>-N <replaceable>hostname</replaceable></arg>
@@ -88,6 +89,19 @@ environments of compile clients.</para></listitem>
 <varlistentry>
 <term><option>-d</option>, <option>--daemonize</option></term>
 <listitem><para>Detach daemon from shell.</para></listitem>
+</varlistentry>
+
+<varlistentry>
+<term><option>--extra-name</option> <parameter>name</parameter></term>
+<listitem>
+<para>Use an additional name (IP address) when considering which jobs coming
+from the scheduler are in fact local jobs that bounced back. This can be useful
+if the scheduler sees the daemon's IP as something the daemon was unable to
+discover, due to NAT between the daemon and the scheduler for example.
+</para>
+<para>This option can be passed by the environment variable ICECC_EXTRA_NAME
+as well; the command line option overrides the environment variable.</para>
+</listitem>
 </varlistentry>
 
 <varlistentry>


### PR DESCRIPTION
The extra name passed as --extra-name or via the ICECC_EXTRA_NAME env
var helps solve local jobs not recognized as local if the IP that the
scheduler sees is not the same as the local bound IP in iceccd, for
example when some IP address translation happens between the node and
the scheduler. This is a fix that does not require a protocol update, but does
require the nodes behind NAT to know their real external IP. 
