### PR TITLE
look for icecc-create-env in the bindir, not the private libdir

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -183,12 +183,12 @@ static int create_native(char **args)
     vector<char*> argv;
     struct stat st;
 
-    if (lstat(PLIBDIR "/icecc-create-env", &st)) {
-        log_error() << PLIBDIR "/icecc-create-env does not exist" << endl;
+    if (lstat(BINDIR "/icecc-create-env", &st)) {
+        log_error() << BINDIR "/icecc-create-env does not exist" << endl;
         return 1;
     }
 
-    argv.push_back(strdup(PLIBDIR "/icecc-create-env"));
+    argv.push_back(strdup(BINDIR "/icecc-create-env"));
 
     if (is_clang) {
         string clang = compiler_path_lookup("clang");

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -529,6 +529,21 @@ icerun_test()
     export PATH=$save_path
 }
 
+# Check that icecc --build-native works.
+buildnativetest()
+{
+    echo Running icecc --build-native test.
+    local tgz=$(PATH="$prefix"/bin:/bin:/usr/bin icecc --build-native 2>&1 | \
+        grep "^creating .*\.tar\.gz$" | sed -e "s/^creating //")
+    if test $? -ne 0; then
+        echo icecc --build-native test failed.
+        exit 2
+    fi
+    rm -f $tgz
+    echo icecc --build-native test successful.
+    echo
+}
+
 # Check that icecc recursively invoking itself is detected.
 recursive_test()
 {
@@ -752,6 +767,8 @@ check_log_message_count()
         exit 2
     fi
 }
+
+buildnativetest
 
 rm -f "$testdir"/scheduler_all.log
 rm -f "$testdir"/localice_all.log


### PR DESCRIPTION
icecc-create-env was moved to the bin directory some time ago:
https://github.com/icecc/icecream/commit/5f580f53430aca86fdbf42bb7c2e6cda84be802f

But it seems that icecc --build-native was still looking for icecc-create-env in the private lib directory.  This patch should fix that.