### PR TITLE
Fix -x flag to properly handle objective-c/c++ files

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -546,10 +546,11 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
 
 #endif
                 job.setLanguage(CompileJob::Lang_CXX);
-            } else if (ext == "mi" || ext == "m"
-                       || ext == "mii" || ext == "mm"
-                       || ext == "M") {
+            } else if (ext == "mi" || ext == "m") {
                 job.setLanguage(CompileJob::Lang_OBJC);
+            } else if (ext == "mii" || ext == "mm"
+                       || ext == "M") {
+                job.setLanguage(CompileJob::Lang_OBJCXX);
             } else if (ext == "s" || ext == "S" // assembler
                        || ext == "ads" || ext == "adb" // ada
                        || ext == "f" || ext == "for" // fortran

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -238,6 +238,7 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
                 argv[i++] = strdup("-Xclang");
                 argv[i++] = strdup(j.workingDirectory().c_str());
             }
+            trace() << "Compiling " << j.inputFile().c_str() << endl;
         }
 
         // HACK: If in / , Clang records DW_AT_name with / prepended .
@@ -289,6 +290,11 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
         // before you add new args, check above for argc
         argv[i] = 0;
         assert(i <= argc);
+
+        for (int currArg = 0; currArg < i; currArg++) {
+          trace() << argv[currArg];
+        }
+        trace() << endl;
 
         close_debug();
 

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -221,7 +221,18 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
         }
 
         argv[i++] = strdup("-x");
-        argv[i++] = strdup((j.language() == CompileJob::Lang_CXX) ? "c++" : "c");
+        if (j.language() == CompileJob::Lang_CXX) {
+          argv[i++] = strdup("c++");
+        } else if (j.language() == CompileJob::Lang_OBJC) {
+          argv[i++] = strdup("objective-c");
+        } else if (j.language() == CompileJob::Lang_OBJCXX) {
+          argv[i++] = strdup("objective-c++");
+        } else if (j.language() == CompileJob::Lang_C) {
+          argv[i++] = strdup("c");
+        } else {
+            error_client(client, "language not supported");
+            log_perror("language not supported");
+        }
 
         if( clang ) {
             // gcc seems to handle setting main file name and working directory fine

--- a/services/job.h
+++ b/services/job.h
@@ -50,6 +50,7 @@ public:
         Lang_C,
         Lang_CXX,
         Lang_OBJC,
+        Lang_OBJCXX,
         Lang_Custom
     } Language;
 
@@ -222,6 +223,9 @@ inline std::ostream &operator<<( std::ostream &output,
         break;
     case CompileJob::Lang_OBJC:
         output << "ObjC";
+        break;
+    case CompileJob::Lang_OBJCXX:
+        output << "ObjC++";
         break;
     }
     return output;


### PR DESCRIPTION
This resolve issue #159 and can now successfully compile the Firefox codebase on a mac using a x86_64 Ubuntu cluster. Seeing more great speed improvements.
