### PR TITLE
include objcopy in the environment if it exists

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -301,7 +301,9 @@ for extrafile in $extrafiles; do
     add_file $extrafile
 done
 
-add_file /usr/bin/objcopy
+if [ -e /usr/bin/objcopy ]; then
+    add_file /usr/bin/objcopy
+fi
 
 if test "$is_darwin" = 1; then
     # add dynamic linker


### PR DESCRIPTION
My systems don't have this file, and building the environment fails for me.