### PR TITLE
Translate German logging message to English

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -1006,7 +1006,7 @@ void Daemon::check_cache_size(const string &new_env)
 
         for (map<string, time_t>::const_iterator it = envs_last_use.begin();
                 it != envs_last_use.end(); ++it) {
-            trace() << "das ist jetzt so: " << it->first << " " << it->second << " " << oldest_time << endl;
+            trace() << "considering cached environment: " << it->first << " " << it->second << " " << oldest_time << endl;
             // ignore recently used envs (they might be in use _right_ now)
             int keep_timeout = 200;
             string native_env_key;


### PR DESCRIPTION
This just translates a one-off string of German in the icecc diagnostic output, so that it's in English like all the rest of the icecc logging that I see when I run `iceccd -vvv`.

I checked with some native German speakers and they suggested that "das ist jetzt so" approximately translates to "this is now".  I'm not sure it's a very clear logging message (regardless of German / English), but let's at least make it consistent and not scare people into thinking they're being attacked by German hackers when they see this one-off German string in their logs. :)