### PR TITLE
Make make Linuxism conditional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,9 @@ AC_CHECK_LIB(lzo2, lzo1x_1_compress, LZO_LDADD=-llzo2,
 	AC_MSG_ERROR([Could not find lzo2 library - please install lzo-devel]))
 AC_SUBST(LZO_LDADD)
 
+AC_CHECK_LIB([dl], [dlsym], [DL_LDADD=-ldl])
+AC_SUBST([DL_LDADD])
+
 # In DragonFlyBSD daemon needs to be linked against libkinfo.
 case $host_os in
   dragonfly*) LIB_KINFO="-lkinfo" ;;

--- a/services/Makefile.am
+++ b/services/Makefile.am
@@ -3,7 +3,7 @@ libicecc_la_SOURCES = job.cpp comm.cpp exitcode.cpp getifaddrs.cpp logging.cpp t
 libicecc_la_LIBADD = \
 	$(LZO_LDADD) \
 	$(CAPNG_LDADD) \
-	-ldl
+	$(DL_LDADD)
 
 libicecc_la_CFLAGS = -fPIC -DPIC
 libicecc_la_CXXFLAGS = -fPIC -DPIC


### PR DESCRIPTION
On FreeBSD, libc provides dl functionality, and there is no separate libdl.

Fixes HEAD’s compilation problems on FreeBSD.