### PR TITLE
You can now be able to set custom Scheduler and Daemon Port

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -64,6 +64,8 @@
 
 using namespace std;
 
+PortCustomConfig ahah;
+
 extern const char *rs_program_name;
 
 static void dcc_show_usage(void)
@@ -403,7 +405,7 @@ int main(int argc, char **argv)
         }
 
         if (!local_daemon) {
-            local_daemon = Service::createChannel("127.0.0.1", 10245, 0/*timeout*/);
+            local_daemon = Service::createChannel("127.0.0.1", ahah.daemonport, 0/*timeout*/);
         }
     } else {
         local_daemon = Service::createChannel(getenv("ICECC_TEST_SOCKET"));

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -102,6 +102,11 @@
 #include "platform.h"
 #include "util.h"
 
+PortCustomConfig ahah;
+
+const int dPORT = ahah.daemonport;
+const int sPORT = ahah.scheduler_port;
+
 static std::string pidFilePath;
 static volatile sig_atomic_t exit_main_loop = 0;
 
@@ -494,8 +499,8 @@ struct Daemon {
         num_cpus = 0;
         scheduler = 0;
         discover = 0;
-        scheduler_port = 8765;
-        daemon_port = 10245;
+        scheduler_port = sPORT;
+        daemon_port = dPORT;
         max_scheduler_pong = MAX_SCHEDULER_PONG;
         max_scheduler_ping = MAX_SCHEDULER_PING;
         current_kids = 0;

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -91,6 +91,8 @@
 
 using namespace std;
 
+PortCustomConfig ahoh;
+
 static string pidFilePath;
 
 static map<int, CompileServer *> fd2cs;
@@ -98,7 +100,7 @@ static volatile sig_atomic_t exit_main_loop = false;
 
 time_t starttime;
 time_t last_announce;
-static unsigned int scheduler_port = 8765;
+static unsigned int scheduler_port = ahoh.schedulerport;
 
 // A subset of connected_hosts representing the compiler servers
 static list<CompileServer *> css;

--- a/services/comm.cpp
+++ b/services/comm.cpp
@@ -57,6 +57,8 @@
 
 using namespace std;
 
+PortCustomConfig ohoh;
+
 /*
  * A generic DoS protection. The biggest messages are of type FileChunk
  * which shouldn't be larger than 100kb. so anything bigger than 10 times
@@ -1195,7 +1197,7 @@ static int open_send_broadcast(int port, const char* buf, int size)
                        << endl;
 
             remote_addr.sin_family = AF_INET;
-            remote_addr.sin_port = htons(port);
+            remote_addr.sin_port = htons(ohoh.schedulerport);
             remote_addr.sin_addr = ((sockaddr_in *)addr->ifa_broadaddr)->sin_addr;
 
             if (sendto(ask_fd, buf, size, 0, (struct sockaddr *)&remote_addr,
@@ -1286,7 +1288,7 @@ DiscoverSched::DiscoverSched(const std::string &_netname, int _timeout,
     , schedname(_schedname)
     , timeout(_timeout)
     , ask_fd(-1)
-    , sport(port)
+    , sport(ohoh.schedulerport)
     , best_version(0)
     , best_start_time(0)
     , multiple(false)

--- a/services/comm.h
+++ b/services/comm.h
@@ -61,6 +61,54 @@
 #define IS_PROTOCOL_34(c) ((c)->protocol >= 34)
 #define IS_PROTOCOL_35(c) ((c)->protocol >= 35)
 
+
+/*
+ * juliengregoire@outlook.com Patch:
+ * Create a class for reading the environement variables and replace the 
+ * the hardcoded ports !
+ *
+ */
+
+class PortCustomConfig
+{	
+	public:
+	
+	unsigned int daemonport;
+	unsigned int schedulerport;
+		
+	char* dp;
+	char* sp;
+	
+	PortCustomConfig()
+	{
+		if(getenv("daemonport") && getenv("schedulerport") != 0)
+		{
+			dp = getenv("daemonport");
+			sp = getenv("schedulerport");
+			this->daemonport = atoi(dp);
+			this->schedulerport = atoi(sp);
+			
+			if(this->daemonport == 0)
+			{
+				this->daemonport = 10245;	
+			}
+			
+			if(this->schedulerport == 0)
+			{
+				this->schedulerport = 8765;
+			}
+		}
+		else
+		{
+			this->daemonport = 10245;
+			this->schedulerport = 8765;			
+		}
+		
+	}
+};
+
+
+
 enum MsgType {
     // so far unknown
     M_UNKNOWN = 'A',

--- a/suse/init.icecream
+++ b/suse/init.icecream
@@ -75,6 +75,23 @@ case "$1" in
                 maxjobs="-m $ICECREAM_MAX_JOBS"
             fi
         fi
+        
+	schedulerport=""
+	if [ "x${ICECREAM_SCHEDULER_PORT}" = "x" ] ; then
+			schedulerport="8765"
+	else
+			schedulerport="$ICECC_SCHEDULER_PORT"
+	fi
+	export schedulerport
+
+	daemonport=""
+	if [ "x${ICECREAM_DAEMON_PORT}" = "x" ] ; then
+			daemonport="10245"
+	else
+			daemonport="$ICECC_DAEMON_PORT"
+	fi
+	export daemonport
+
 	startproc /usr/sbin/iceccd -d $logfile $nice $scheduler $netname -u icecream -b "$ICECREAM_BASEDIR" $maxjobs $noremote
 	rc_status -v
 	;;

--- a/suse/sysconfig.icecream
+++ b/suse/sysconfig.icecream
@@ -90,3 +90,17 @@ ICECREAM_ALLOW_REMOTE="yes"
 # path if your /tmp is small - but the user icecream has to write to it.
 # 
 ICECREAM_BASEDIR="/var/cache/icecream"
+
+# Julien gregoire Patch here !
+
+## Type: Integer(1:65535)
+## Description: Scheduler port, to receive broadcast signals from the nodes and to maintain the connection between nodes and scheduler.
+## Default: 8765
+ICECREAM_SCHEDULER_PORT=""
+
+
+## Type: Integer(1:65535)
+## Description: DAEMON port, to receive compilation jobs sent by the scheduler
+## Default: 10245
+ICECREAM_DAEMON_PORT=""
+


### PR DESCRIPTION
You can now launch multiple Scheduler and/or daemon in chroots environement by
setting manually the ports in the icecream configuration file.

I merged manually my old work with this new release, so it might be have some error (I don't hope so...).

To see my changes, in your terminal at the root dir of the sources, search with:

- grep -nre "ahah"
- grep -nre "ohoh"
- grep -nre "ahoh"
- grep -nre "PortCusom"

If the ports are not set, icecream take the default ports.

 I've done thoose modifications to be able to have one big scheduler server, launched in multiples chroots (with different port), and multiples daemon on the same chroots as the scheduler on compilation-nodes. I work in a company who need to have specific chroots env by products. Because the toolchains provided by intel or broadcom or others, makes hard link with files in the system itself... 





