### PR TITLE
Better handle errors extracting environment

### DIFF
--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -510,10 +510,11 @@ pid_t start_install_environment(const std::string &basename, const std::string &
     flush_debug();
     pid_t pid = fork();
 
-    if(-1 == pid) {
+    if (pid == -1) {
         log_perror("fork - trying to run tar");
         return 0;
-    } else if (pid) {
+    }
+    if (pid) {
         trace() << "pid " << pid << endl;
         close(fds[0]);
         pipe_to_stdin = fds[1];
@@ -568,7 +569,7 @@ pid_t start_install_environment(const std::string &basename, const std::string &
     argv[5] = 0;
     execv(argv[0], argv);
     log_perror("execv failed");
-    _exit(142);
+    _exit(100);
 }
 
 

--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -510,7 +510,10 @@ pid_t start_install_environment(const std::string &basename, const std::string &
     flush_debug();
     pid_t pid = fork();
 
-    if (pid) {
+    if(-1 == pid) {
+        log_perror("fork - trying to run tar");
+        return 0;
+    } else if (pid) {
         trace() << "pid " << pid << endl;
         close(fds[0]);
         pipe_to_stdin = fds[1];
@@ -563,7 +566,9 @@ pid_t start_install_environment(const std::string &basename, const std::string &
 
     argv[4] = strdup("-");
     argv[5] = 0;
-    _exit(execv(argv[0], argv));
+    execv(argv[0], argv);
+    log_perror("execv failed");
+    _exit(142);
 }
 
 
@@ -718,6 +723,8 @@ bool verify_env(MsgChannel *client, const string &basedir, const string &target,
                 uid_t user_uid, gid_t user_gid)
 {
     if (target.empty() || env.empty()) {
+        error_client(client, "verify_env: target or env empty");
+        log_error() << "verify_env target or env empty\n\t" << target << "\n\t" << env << endl;
         return false;
     }
 


### PR DESCRIPTION
I'm investigating errors installing the icecc environment.

Some of my users have found a cases where iceccd is hung (which is to say calling gcc hangs when gcc is icecc), and the user found some processes with "tar | tar | gzip" strung together under the user for icecc (only iceccd is running as this user).  I know this is a little generic, but it is hard to get clear information from these users.  It isn't clear if this fixes their issue but it seems like it could.