### PR TITLE
Add a travis continuous integration configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: cpp
+
+script:
+  - ./autogen.sh
+  - ./configure --prefix=$PWD/_inst
+  - make
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test; fi
+
+matrix:
+  include:
+  - os: linux
+    sudo: true # for setcap so we can run the tests in chroot.
+  - os: osx
+    before_install:
+      - brew update
+      - brew install lzo docbook2x
+
+addons:
+  apt:
+    packages:
+    - libcap-ng-dev
+    - libcap-ng-utils
+    - liblzo2-dev
+    - docbook2x
+    - realpath


### PR DESCRIPTION
Describe the build for linux and macOS, and run the tests on linux. I find this very helpful for evaluating pull requests. Someone with commit access will have to sign in to https://travis-ci.org/ and add the repo for feedback to be available.

Closes #195