### PR TITLE
fix hang on linking when daemon has -m=0

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -1210,7 +1210,7 @@ bool Daemon::handle_job_done(Client *cl, JobDoneMsg *m)
 
 void Daemon::handle_old_request()
 {
-    while ((current_kids + clients.active_processes) < max_kids) {
+    while ((current_kids + clients.active_processes) < std::max((unsigned int)1, max_kids)) {
 
         Client *client = clients.get_earliest_client(Client::LINKJOB);
 

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -590,6 +590,12 @@ static CompileServer *pick_server(Job *job)
             continue;
         }
 
+        // Ignore ineligible servers
+        if (!cs->is_eligible(job)) {
+            trace() << cs->nodeName() << " not eligible" << endl;
+            continue;
+        }
+
         // incompatible architecture or busy installing
         if (!cs->can_install(job).size()) {
 #if DEBUG_SCHEDULER > 2


### PR DESCRIPTION
A slightly modified version of #148 that allows leeching daemons with -m=0 while still allowing clients on the leeching machines to run compile/link jobs without hanging.