### PR TITLE
log_perror and log_errno should allow streaming more information

### DIFF
--- a/services/logging.h
+++ b/services/logging.h
@@ -104,14 +104,14 @@ static inline std::ostream &trace()
     return output_date(*logfile_trace);
 }
 
-static inline void log_errno(const char *prefix, int tmp_errno)
+static inline std::ostream & log_errno(const char *prefix, int tmp_errno)
 {
-    log_error() << prefix << " " << strerror(tmp_errno) << std::endl;
+    return log_error() << prefix << " " << strerror(tmp_errno) << std::endl;
 }
 
-static inline void log_perror(const char *prefix)
+static inline std::ostream & log_perror(const char *prefix)
 {
-    log_errno(prefix, errno);
+    return log_errno(prefix, errno);
 }
 
 class log_block


### PR DESCRIPTION
Often when a system call fails there is dynamic information that would be helpful to log as well, but that requires two calls to logging which is tricky enough that nobody is doing that.