### PR TITLE
Run jobs locally on submitter if possible

### DIFF
--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -577,6 +577,12 @@ static CompileServer *pick_server(Job *job)
 
     uint matches = 0;
 
+    if (job->submitter()->maxJobs() > int(job->submitter()->jobList().size())) {
+        // Prefer running locally if the submitter has capacity to minimize
+        // latency when editing and compiling a small number of files.
+        return job->submitter();
+    }
+
     for (list<CompileServer *>::iterator it = css.begin(); it != css.end(); ++it) {
         CompileServer *cs = *it;
 


### PR DESCRIPTION
This minimizes the latency for single-file edit-compile cycles by only
shipping work over the network when there is more than can be done locally.

I've been running a scheduler with this patch for the past month and it has been working well. I initially wrote it when I noticed that small compiles were taking several seconds longer than they were without icecream.

I don't know this codebase well, so there may be a better way to do this. Ideally we could also give everyone priority on their own box, so no one else can schedule jobs on my box while I have jobs in the queue. But I couldn't figure out how to do that.