### PR TITLE
clang related changes

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -404,6 +404,18 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                        || str_equal("-MG", a)
                        || str_equal("-MP", a)) {
                 args.append(a, Arg_Local);
+            } else if (str_equal("-arch", a)) {
+                args.append(a, Arg_Remote);
+                /* skip next word, being option argument */
+                if (argv[i + 1]) {
+                    args.append(argv[++i], Arg_Remote);
+                }
+            } else if (str_equal("-target", a)) {
+                args.append(a, Arg_Remote);
+                /* skip next word, being option argument */
+                if (argv[i + 1]) {
+                    args.append(argv[++i], Arg_Remote);
+                }
             } else if (str_equal("-fno-color-diagnostics", a)) {
                 explicit_color_diagnostics = true;
                 args.append(a, Arg_Rest);

--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -159,7 +159,18 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                 /* as above but with extra argument */
             } else if (!strcmp(a, "-MT") || !strcmp(a, "-MQ")) {
                 args.append(a, Arg_Local);
-                args.append(argv[++i], Arg_Local);
+                ++i;
+                if (argv[i][0] == '"') {
+                    std::string value = argv[i];
+
+                    while (*value.rbegin() != '"') {
+                        value.append(" ").append(argv[++i]);
+                    };
+
+                    args.append(value, Arg_Local);
+                } else {
+                    args.append(argv[i], Arg_Local);
+                }
                 /* as above but with extra argument */
             } else if (a[1] == 'M') {
                 /* -M(anything else) causes the preprocessor to

--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -101,10 +101,10 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
     string dwofile;
 
 #if CLIENT_DEBUG > 1
-    trace() << "scanning arguments ";
+    trace() << "scanning arguments" << endl;
 
     for (int index = 0; argv[index]; index++) {
-        trace() << argv[index] << " ";
+        trace() << " " << argv[index] << endl;
     }
 
     trace() << endl;

--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -367,6 +367,8 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                        || str_equal("-iprefix", a)
                        || str_equal("-iwithprefix", a)
                        || str_equal("-isystem", a)
+                       || str_equal("-cxx-isystem", a)
+                       || str_equal("-c-isystem", a)
                        || str_equal("-iquote", a)
                        || str_equal("-imultilib", a)
                        || str_equal("-isysroot", a)


### PR DESCRIPTION
When integrating clang and the osxcross compiler we noticed several issues:

- ICU uses `-MT "stubdata.d stubdata.o stubdata.ao"`parameter when building, and the client was receiving three parameters `"stubdata.d` `stubdata.o` and `stubdata.ao"`. That was breaking the command line
- osxcross passes `-target x86_64-apple-darwin15`and `-arch x86_64`. The client was interpreting those as file names and was complaining that more than one file was being specified
- the client didn't understand clang's `-c-isystem` and `-cxx-isystem` switches

This pull request addresses all those issues
