### PR TITLE
clang related changes

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -404,6 +404,18 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                        || str_equal("-MG", a)
                        || str_equal("-MP", a)) {
                 args.append(a, Arg_Local);
+            } else if (str_equal("-arch", a)) {
+                args.append(a, Arg_Remote);
+                /* skip next word, being option argument */
+                if (argv[i + 1]) {
+                    args.append(argv[++i], Arg_Remote);
+                }
+            } else if (str_equal("-target", a)) {
+                args.append(a, Arg_Remote);
+                /* skip next word, being option argument */
+                if (argv[i + 1]) {
+                    args.append(argv[++i], Arg_Remote);
+                }
             } else if (str_equal("-fno-color-diagnostics", a)) {
                 explicit_color_diagnostics = true;
                 args.append(a, Arg_Rest);

--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -101,10 +101,10 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
     string dwofile;
 
 #if CLIENT_DEBUG > 1
-    trace() << "scanning arguments ";
+    trace() << "scanning arguments" << endl;
 
     for (int index = 0; argv[index]; index++) {
-        trace() << argv[index] << " ";
+        trace() << " " << argv[index] << endl;
     }
 
     trace() << endl;

--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -367,6 +367,8 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                        || str_equal("-iprefix", a)
                        || str_equal("-iwithprefix", a)
                        || str_equal("-isystem", a)
+                       || str_equal("-cxx-isystem", a)
+                       || str_equal("-c-isystem", a)
                        || str_equal("-iquote", a)
                        || str_equal("-imultilib", a)
                        || str_equal("-isysroot", a)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1053,7 +1053,7 @@ if test -x $CLANGXX; then
     rm "$testdir"/includes.o
     run_ice "" "remote" 0 $CLANGXX -Wall -Werror -cxx-isystem ./ -c includes.cpp -o "$testdir"/includes.o
     rm "$testdir"/includes.o
-    run_ice "" "remote" 0 $CLANGXX -Wall -Werror -target $(uname -m) -c includes.cpp -o "$testdir"/includes.o
+    run_ice "" "remote" 0 $CLANGXX -Wall -Werror -target x86_64-linux-gnu -c includes.cpp -o "$testdir"/includes.o
     rm "$testdir"/includes.o
 
     # test -frewrite-includes usage

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1051,6 +1051,10 @@ if test -x $CLANGXX; then
     rm "$testdir"/plain.o
     run_ice "" "remote" 0 $CLANGXX -Wall -Werror -c includes.cpp -o "$testdir"/includes.o
     rm "$testdir"/includes.o
+    run_ice "" "remote" 0 $CLANGXX -Wall -Werror -cxx-isystem ./ -c includes.cpp -o "$testdir"/includes.o
+    rm "$testdir"/includes.o
+    run_ice "" "remote" 0 $CLANGXX -Wall -Werror -target $(uname -m) -c includes.cpp -o "$testdir"/includes.o
+    rm "$testdir"/includes.o
 
     # test -frewrite-includes usage
     $CLANGXX -E -Werror -frewrite-includes messages.cpp | grep -q '^# 1 "messages.cpp"$' >/dev/null 2>/dev/null


### PR DESCRIPTION
When integrating clang and the osxcross compiler we noticed several issues:

- osxcross passes `-target x86_64-apple-darwin15`and `-arch x86_64`. The client was interpreting those as file names and was complaining that more than one file was being specified
- the client didn't understand clang's `-c-isystem` and `-cxx-isystem` switches

This pull request addresses all those issues. Some tests to make sure the new command line switches don't trigger a local build are provided.
