### PR TITLE
Make clang's -arch and -target Arch_Rest flags

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -405,16 +405,16 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                        || str_equal("-MP", a)) {
                 args.append(a, Arg_Local);
             } else if (str_equal("-arch", a)) {
-                args.append(a, Arg_Remote);
+                args.append(a, Arg_Rest);
                 /* skip next word, being option argument */
                 if (argv[i + 1]) {
-                    args.append(argv[++i], Arg_Remote);
+                    args.append(argv[++i], Arg_Rest);
                 }
             } else if (str_equal("-target", a)) {
-                args.append(a, Arg_Remote);
+                args.append(a, Arg_Rest);
                 /* skip next word, being option argument */
                 if (argv[i + 1]) {
-                    args.append(argv[++i], Arg_Remote);
+                    args.append(argv[++i], Arg_Rest);
                 }
             } else if (str_equal("-fno-color-diagnostics", a)) {
                 explicit_color_diagnostics = true;


### PR DESCRIPTION
clang needs to know -arch and -target also when linking, which happens locally. Move those flags to Arg_Rest from Arg_Remote.