### PR TITLE
remove unused job_in_fd arg from work_it

### DIFF
--- a/daemon/serve.cpp
+++ b/daemon/serve.cpp
@@ -262,7 +262,7 @@ int handle_connection(const string &basedir, CompileJob *job,
             obj_file = output_dir + '/' + file_name;
             dwo_file = obj_file.substr(0, obj_file.find_last_of('.')) + ".dwo";
 
-            ret = work_it(*job, job_stat, client, rmsg, tmp_path, job_working_dir, relative_file_path, mem_limit, client->fd, -1);
+            ret = work_it(*job, job_stat, client, rmsg, tmp_path, job_working_dir, relative_file_path, mem_limit, client->fd);
         }
         else if ((ret = dcc_make_tmpnam(prefix_output, ".o", &tmp_output, 0)) == 0) {
             obj_file = tmp_output;
@@ -270,7 +270,7 @@ int handle_connection(const string &basedir, CompileJob *job,
             string build_path = obj_file.substr(0, obj_file.find_last_of('/'));
             string file_name = obj_file.substr(obj_file.find_last_of('/')+1);
 
-            ret = work_it(*job, job_stat, client, rmsg, build_path, "", file_name, mem_limit, client->fd, -1);
+            ret = work_it(*job, job_stat, client, rmsg, build_path, "", file_name, mem_limit, client->fd);
         }
 
         if (ret) {

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -94,7 +94,7 @@ error_client(MsgChannel *client, string error)
 
 int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileResultMsg &rmsg,
             const std::string &tmp_root, const std::string &build_path, const std::string &file_name,
-            unsigned long int mem_limit, int client_fd, int /*job_in_fd*/)
+            unsigned long int mem_limit, int client_fd)
 {
     rmsg.out.erase(rmsg.out.begin(), rmsg.out.end());
     rmsg.out.erase(rmsg.out.begin(), rmsg.out.end());
@@ -578,9 +578,6 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
                     sock_in[1] = -1;
                     continue;
                 }
-
-                // The fd is -1 anyway
-                //write(job_in_fd, fcmsg->buffer + off, bytes);
 
                 off += bytes;
 

--- a/daemon/workit.h
+++ b/daemon/workit.h
@@ -53,6 +53,6 @@ enum job_stat_fields { in_compressed, in_uncompressed, out_uncompressed, exit_co
 
 extern int work_it(CompileJob &j, unsigned int job_stats[], MsgChannel *client, CompileResultMsg &msg,
                    const std::string &tmp_root, const std::string &build_path, const std::string &file_name,
-                   unsigned long int mem_limit, int client_fd, int job_in_fd);
+                   unsigned long int mem_limit, int client_fd);
 
 #endif


### PR DESCRIPTION
This arg was disabled back in 2009: f34827531687e7d69f9815294c862cc2f5013eba