### PR TITLE
recognise some more clang OOM symptoms

### DIFF
--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -647,6 +647,8 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
                             || (rmsg.err.find("memory exhausted") != string::npos)
                             || (rmsg.err.find("out of memory allocating") != string::npos)
                             || (rmsg.err.find("annot allocate memory") != string::npos)
+                            || (rmsg.err.find("failed to map segment from shared object") != string::npos)
+                            || (rmsg.err.find("Assertion `NewElts && \"Out of memory\"' failed") != string::npos)
                             || (rmsg.err.find("terminate called after throwing an instance of 'std::bad_alloc'") != string::npos)
                             || (rmsg.err.find("llvm::MallocSlabAllocator::Allocate") != string::npos)) {
                         // the relation between ulimit and memory used is pretty thin ;(


### PR DESCRIPTION
Attempt to recognise some more clang OOM symptoms, so affected build jobs
can be attempted locally:

1) /usr/bin/clang: error while loading shared libraries: libgcc_s.so.1: failed to map segment from shared object
2) void llvm::SmallVectorBase::grow_pod(void *, size_t, size_t): Assertion `NewElts && "Out of memory"' failed.