### PR TITLE
typo fixes

### DIFF
--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -345,7 +345,7 @@ static void receive_file(const string& output_file, MsgChannel* cserver)
         if (msg->type != M_FILE_CHUNK) {
             unlink(tmp_file.c_str());
             delete msg;
-            throw client_error(20, "Error 20 - unexpcted message");
+            throw client_error(20, "Error 20 - unexpected message");
         }
 
         FileChunkMsg *fcmsg = dynamic_cast<FileChunkMsg*>(msg);

--- a/doc/man-icecc-scheduler.1.xml
+++ b/doc/man-icecc-scheduler.1.xml
@@ -91,7 +91,7 @@ controls.</para></listitem>
 <varlistentry>
 <term><option>-u</option>, <option>--user-uid</option>
 <parameter>user</parameter></term>
-<listitem><para>Specifiy the system user used by the daemon, which must be
+<listitem><para>Specify the system user used by the daemon, which must be
 different than <quote>root</quote>. If not specified, the daemon defaults
 to the <quote>icecc</quote> system user if available, or <quote>nobody</quote>
 if not.</para></listitem>

--- a/doc/man-iceccd.1.xml
+++ b/doc/man-iceccd.1.xml
@@ -143,7 +143,7 @@ reasons, when this is enabled scheduler should use --persistent-client-connectio
 <varlistentry>
 <term><option>-u</option>, <option>--user-uid</option>
 <parameter>user</parameter></term>
-<listitem><para>Specifiy the system user used by the daemon, which must be
+<listitem><para>Specify the system user used by the daemon, which must be
 different than <quote>root</quote>. If not specified, the daemon defaults
 to the <quote>icecc</quote> system user if available, or <quote>nobody</quote>
 if not.</para></listitem>

--- a/doc/man-icecream.7.xml
+++ b/doc/man-icecream.7.xml
@@ -108,7 +108,7 @@ environment. The file will have a random unique name like
 more expressive for your convenience, e.g. <filename>i386-3.3.1.tar.bz2</filename>. Set
 <command>ICECC_VERSION=<replaceable>filename_of_archive_containing_your_environment</replaceable></command>
 in the shell environment where you start the compile jobs and the file will be
-transfered to the daemons where your compile jobs run and installed to a chroot
+transferred to the daemons where your compile jobs run and installed to a chroot
 environment for executing the compile jobs in the environment fitting to the
 environment of the client. This requires that the icecream daemon runs as root.
 </para>
@@ -295,7 +295,7 @@ Numbers of my test case (some STL C++ genetic algorithm)
 
 <para>The icecream overhead is quite huge as you might notice, but the compiler
 cannot interleave preprocessing with compilation and the file needs to be
-read/written once more and in between the file is transfered.</para>
+read/written once more and in between the file is transferred.</para>
 
 <para>But even if the other computer is faster, using <command>g++</command> on my local machine
 is faster. If you are (for whatever reason) alone in your network at some point,


### PR DESCRIPTION
- "specifiy" -> "specify"
- "transfered" -> "transferred"
- "unexpcted" -> "unexpected"