### PR TITLE
client: expand string buffer for long value

### DIFF
--- a/client/util.cpp
+++ b/client/util.cpp
@@ -194,7 +194,7 @@ bool dcc_lock_host(int &lock_fd)
     if (pwd) {
         fname += pwd->pw_name;
     } else {
-        char buffer[10];
+        char buffer[12];
         sprintf(buffer, "%ld", (long)getuid());
         fname += buffer;
     }


### PR DESCRIPTION
Make the string buffer for a 'long' value sligtly bigger, which should cover all the potential values.