### PR TITLE
Fix gentoo make.conf Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ Icecream on gentoo
 -------------------------------------------------------------------------------------
 
 -   It is recommended to remove all processor specific optimizations
-    from the CFLAGS line in /etc/make.conf. On the aKademy cluster it
+    from the CFLAGS line in /etc/portage/make.conf. On the aKademy cluster it
     proved useful to use only "-O2", otherwise there are often internal
     compiler errors, if not all computers have the same processor
     type/version


### PR DESCRIPTION
The ``make.conf`` location has been moved in end-2012: https://forums.gentoo.org/viewtopic-p-7137202.html

Apparently this README has been written long ago and I am nut sure if the other parts of it are up to date with respect to current Gentoo. Maybe someone else might with more insight can have a look at the other points.