### PR TITLE
Fix some easy codacy issues - also document C++11 is required

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+1.2 (in progress)
+C++11 is required
+
 1.1
  - revert "Add load control for preprocessing"
  - better handle clang arugments with spaces

--- a/README
+++ b/README
@@ -6,6 +6,8 @@ form of process accounting in there.
 How to install icecream
 =======================
 
+You must have a compiler that supports at least C++11.
+
 cd icecream
 ./autogen.sh
 ./configure --prefix=/opt/icecream

--- a/client/local.cpp
+++ b/client/local.cpp
@@ -337,9 +337,9 @@ int build_local(CompileJob &job, MsgChannel *local_daemon, struct rusage *used)
     if (color_output) {
         string s_ccout;
         char buf[250];
-        int r;
 
         for (;;) {
+	    int r;
             while ((r = read(pf[0], buf, sizeof(buf) - 1)) > 0) {
                 buf[r] = '\0';
                 s_ccout.append(buf);

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -173,7 +173,7 @@ static int create_native(char **args)
     char **extrafiles = args;
     string machine_name = determine_platform();
 
-    if (machine_name.find("Darwin") == 0)
+    if (machine_name.compare(0, 6, "Darwin") == 0)
         is_clang = true;
     // Args[0] may be a compiler or the first extra file.
     if (args[0] && ((!strcmp(args[0], "clang") && (is_clang = true))

--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -63,7 +63,7 @@ namespace
 
 struct CharBufferDeleter {
     char *buf;
-    CharBufferDeleter(char *b) : buf(b) {}
+    explicit CharBufferDeleter(char *b) : buf(b) {}
     ~CharBufferDeleter() {
         free(buf);
     }
@@ -748,16 +748,11 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
     int torepeat = 1;
     bool has_split_dwarf = job.dwarfFissionEnabled();
 
-    // older compilers do not support the options we need to make it reproducible
-#if defined(__GNUC__) && ( ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 3) ) || (__GNUC__ >=4) )
-
     if (!compiler_is_clang(job)) {
         if (rand() % 1000 < permill) {
             torepeat = 3;
         }
     }
-
-#endif
 
     trace() << job.inputFile() << " compiled " << torepeat << " times on "
             << job.targetPlatform() << "\n";

--- a/daemon/serve.cpp
+++ b/daemon/serve.cpp
@@ -174,7 +174,6 @@ int handle_connection(const string &basedir, CompileJob *job,
     }
 
     Msg *msg = 0; // The current read message
-    unsigned int job_id = 0;
     string tmp_path, obj_file, dwo_file;
 
     try {
@@ -203,7 +202,7 @@ int handle_connection(const string &basedir, CompileJob *job,
         int ret;
         unsigned int job_stat[8];
         CompileResultMsg rmsg;
-        job_id = job->jobID();
+        unsigned int job_id = job->jobID();
 
         memset(job_stat, 0, sizeof(job_stat));
 

--- a/services/comm.cpp
+++ b/services/comm.cpp
@@ -989,7 +989,6 @@ Msg *MsgChannel::get_msg(int timeout)
 {
     Msg *m = 0;
     enum MsgType type;
-    uint32_t t;
 
     if (!wait_for_msg(timeout)) {
         trace() << "!wait_for_msg()\n";
@@ -1012,6 +1011,7 @@ Msg *MsgChannel::get_msg(int timeout)
     if (text_based) {
         type = M_TEXT;
     } else {
+        uint32_t t;
         *this >> t;
         type = (enum MsgType) t;
     }

--- a/services/tempfile.c
+++ b/services/tempfile.c
@@ -64,7 +64,6 @@ int dcc_make_tmpnam(const char *prefix, const char *suffix, char **name_ret, int
 {
     unsigned long random_bits;
     unsigned long tries = 0;
-    int fd;
     size_t tmpname_length;
     char *tmpname;
 
@@ -103,7 +102,7 @@ int dcc_make_tmpnam(const char *prefix, const char *suffix, char **name_ret, int
          *
          * The permissions are tight because nobody but this process
          * and our children should do anything with it. */
-        fd = open(tmpname, O_WRONLY | O_CREAT | O_EXCL, 0600);
+        int fd = open(tmpname, O_WRONLY | O_CREAT | O_EXCL, 0600);
 
         if (fd == -1) {
             /* Don't try getting a file too often.  Safety net against


### PR DESCRIPTION
C++11 is required because I removed a #ifdef for very old gcc versions.  Otherwise this is mostly about fixing static analysis issues that cadacy points out in our code.

There are still more issues, to look at, I'm out of time today