### PR TITLE
Clang tests build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ tests/test-suite.log
 tests/testargs
 tests/testargs.log
 tests/testargs.trs
+tests/test-setup.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: cpp
 
 script:
+# Only the clang(-3.4) package provide /usr/bin/clang, but this path is hardcoded in icecream.
+# So for now make icecream use this newer version.
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ln -s /usr/bin/clang-3.9 /usr/bin/clang; sudo ln -s /usr/bin/clang++-3.9 /usr/bin/clang++; export LLVM_CONFIG=/usr/bin/llvm-config-3.9; fi
   - ./autogen.sh
   - ./configure --prefix=$PWD/_inst
   - make
@@ -67,7 +70,9 @@ before_script:
 addons:
   apt:
     packages:
-    - clang
+    - clang-3.9
+    - libclang-3.9-dev
+    - llvm-3.9-dev
     - libcap-ng-dev
     - libcap-ng-utils
     - liblzo2-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,3 +73,4 @@ addons:
     - liblzo2-dev
     - docbook2x
     - realpath
+    - gdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - ./autogen.sh
   - ./configure --prefix=$PWD/_inst
   - make
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test-strict; fi
 
 matrix:
   include:

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,3 +17,5 @@ dist-hook:
 
 test: install
 	$(MAKE) -C tests $@
+test-strict: install
+	$(MAKE) -C tests $@

--- a/README.md
+++ b/README.md
@@ -202,21 +202,8 @@ There is no known workaround, either disable `-Werror` or fix the code.
 
 ### clang tries to read /proc/cpuinfo and fails
 
-This is a bug in clang 4.0. https://bugs.llvm.org/show_bug.cgi?id=33008 
-It should be fixed in the future, but if you have a broken release you can work around this by
-creating a custom environment and adding /proc/cpuinfo to it.
-
-```
-/usr/lib/icecc/icecc-create-env --clang /usr/bin/clang /usr/lib/icecc/compilerwrapper --addfile /proc/cpuinfo
-```
-
-Do not apply this work around if you do not need it. /proc/cpuinfo is machine specific so and this work 
-around will place wrong information in it. In the case of the bug in clang 4.0 this file is checked for 
-existence but the contents are not actually used, but it is possible future versions of clang/gcc will use
-this file if it exists for something else.
-
-see [Using icecream in heterogeneous environments](#using-icecream-in-heterogeneous-environments) 
-for more information on using icecc-create-env.
+This is a problem of clang 4.0 and newer: https://bugs.llvm.org/show_bug.cgi?id=33008 
+The most recent Icecream version works around this problem.
 
 Supported platforms
 ---------------------------------------------------------------------------------------

--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -299,6 +299,14 @@ if test -n "$clang"; then
 
     add_file $($added_clang -print-prog-name=as) /usr/bin/as
 
+    # HACK: Clang4.0 and later access /proc/cpuinfo and report an error when they fail
+    # to find it, even if they use a fallback mechanism, making the error useless
+    # (at least in this case). Since the file is not really needed, create a fake one.
+    mkdir $tempdir/fakeproc
+    mkdir $tempdir/fakeproc/proc
+    touch $tempdir/fakeproc/proc/cpuinfo
+    add_file $tempdir/fakeproc/proc/cpuinfo /proc/cpuinfo
+
     # clang always uses its internal .h files
     clangincludes=$(dirname $($added_clang -print-file-name=include/limits.h))
     clangprefix=$(dirname $(dirname $added_clang))

--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -28,6 +28,16 @@ is_contained ()
   esac
 }
 
+# Avoid /../ components in paths such as /usr/X11/../lib64 .
+# This could use realpath, but that's reportedly not that widely available.
+convert_path_cdup ()
+{
+  local filename="$1"
+  local directory=`dirname $filename`
+  local fixed_directory=`cd "$directory" >/dev/null && pwd -P`
+  echo ${fixed_directory}/`basename $filename`
+}
+
 add_file ()
 {
   local name="$1"
@@ -39,6 +49,8 @@ add_file ()
   # ls -H isn't really the same as readlink, but
   # readlink is not portable enough.
   path=`ls -H $path`
+  name=`convert_path_cdup $name`
+  path=`convert_path_cdup $path`
   toadd="$name=$path"
   if test "$name" = "$path"; then
     toadd=$path

--- a/configure.ac
+++ b/configure.ac
@@ -296,6 +296,7 @@ AC_CONFIG_FILES([ compilerwrapper/Makefile ])
 AC_CONFIG_FILES([ scheduler/Makefile ])
 AC_CONFIG_FILES([ tests/Makefile ])
 AC_CONFIG_FILES([ client/icecc-create-env ])
+AC_CONFIG_FILES([ tests/test-setup.sh ])
 AC_OUTPUT([ suse/icecream.spec ])
 if test "$prefix" = NONE; then
   prefix=$ac_default_prefix

--- a/configure.ac
+++ b/configure.ac
@@ -195,6 +195,24 @@ case $host_os in
 esac
 AC_SUBST(LIB_KINFO)
 
+# Note that icecream currently uses a hardcoded /usr/bin/{gcc|g++|clang} path
+# in some places (creating native environment), so using compilers
+# in a different location is currently tricky.
+if test -z "$CLANG"; then
+    CLANG=/usr/bin/clang
+fi
+if test -z "$CLANGXX"; then
+    CLANGXX=/usr/bin/clang++
+fi
+if test -z "$LLVM_CONFIG"; then
+    LLVM_CONFIG=/usr/bin/llvm-config
+fi
+AC_CHECK_PROG(CLANG,$CLANG,$CLANG)
+AC_CHECK_PROG(CLANGXX,$CLANGXX,$CLANGXX)
+AC_CHECK_PROG(LLVM_CONFIG,$LLVM_CONFIG,$LLVM_CONFIG)
+AC_SUBST(CLANG)
+AC_SUBST(CLANGXX)
+
 AC_ARG_ENABLE(clang-rewrite-includes,
     AS_HELP_STRING([--enable-clang-rewrite-includes],
         [Use by default Clang's -frewrite-includes option.]))
@@ -204,7 +222,6 @@ if test "$enable_clang_rewrite_includes" = "yes"; then
 elif test "$enable_clang_rewrite_includes" = "no"; then
     true  # do not enable
 else
-    AC_CHECK_PROG(CLANG,clang,clang)
     if test -n "$CLANG"; then
         AC_MSG_CHECKING([whether clang -Werror works for unknown options])
         $CLANG -Werror -totallybogusoption -E - >/dev/null 2>/dev/null
@@ -226,14 +243,11 @@ else
 fi
 
 HAVE_CLANG_DEVEL_DEP=
-CLANGXX=
 LLVM_CXXFLAGS=
-AC_CHECK_PROG(CLANGXX,clang++,clang++)
 if test -n "$CLANGXX"; then
     AC_MSG_CHECKING([Clang version])
     clang_version=`$CLANGXX --version`
     AC_MSG_RESULT([$clang_version])
-    AC_CHECK_PROG(LLVM_CONFIG,llvm-config,llvm-config)
     LLVM_CXXFLAGS="-D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"
     if test -n "$LLVM_CONFIG"; then
         LLVM_CXXFLAGS=`$LLVM_CONFIG --cxxflags`
@@ -253,7 +267,6 @@ if test -n "$CLANGXX"; then
     AC_LANG_POP([C++])
 fi
 AC_SUBST(HAVE_CLANG_DEVEL_DEP)
-AC_SUBST(CLANGXX)
 AC_SUBST(LLVM_CXXFLAGS)
 
 AC_ARG_ENABLE(clang-wrappers,
@@ -266,7 +279,6 @@ if test "$enable_clang_wrappers" = "yes"; then
 elif test "$enable_clang_wrappers" = "no"; then
     true # do not enable
 else
-    AC_CHECK_PROG(CLANG,clang,clang)
     if test -n "$CLANG"; then
         CLANG_SYMLINK_WRAPPERS='clang clang++'
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -226,15 +226,35 @@ else
 fi
 
 HAVE_CLANG_DEVEL_DEP=
-AC_CHECK_PROG(CLANG,clang,clang)
-AC_LANG_PUSH([C++])
-save_CPPFLAGS=$CPPFLAGS
-CPPFLAGS="$CPPFLAGS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"
-AC_CHECK_HEADER(clang/AST/RecursiveASTVisitor.h,
-    [ HAVE_CLANG_DEVEL_DEP=clangplugin ] )
-CPPFLAGS="$save_CPPFLAGS"
-AC_LANG_POP([C++])
+CLANGXX=
+LLVM_CXXFLAGS=
+AC_CHECK_PROG(CLANGXX,clang++,clang++)
+if test -n "$CLANGXX"; then
+    AC_MSG_CHECKING([Clang version])
+    clang_version=`$CLANGXX --version`
+    AC_MSG_RESULT([$clang_version])
+    AC_CHECK_PROG(LLVM_CONFIG,llvm-config,llvm-config)
+    LLVM_CXXFLAGS="-D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"
+    if test -n "$LLVM_CONFIG"; then
+        LLVM_CXXFLAGS=`$LLVM_CONFIG --cxxflags`
+    fi
+    AC_LANG_PUSH([C++])
+    save_CPPFLAGS=$CPPFLAGS
+    save_CXXCPP=$CXXCPP
+    save_CXX=$CXX
+    CPPFLAGS="$CPPFLAGS $LLVM_CXXFLAGS"
+    CXXCPP="$CLANGXX -E"
+    CXX=$CLANGXX
+    AC_CHECK_HEADER(clang/AST/RecursiveASTVisitor.h,
+        [ HAVE_CLANG_DEVEL_DEP=clangplugin ] )
+    CPPFLAGS="$save_CPPFLAGS"
+    CXXCPP="$save_CXXCPP"
+    CXX="$save_CXX"
+    AC_LANG_POP([C++])
+fi
 AC_SUBST(HAVE_CLANG_DEVEL_DEP)
+AC_SUBST(CLANGXX)
+AC_SUBST(LLVM_CXXFLAGS)
 
 AC_ARG_ENABLE(clang-wrappers,
     AS_HELP_STRING([--enable-clang-wrappers],

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -617,7 +617,7 @@ bool Daemon::setup_listen_fds()
             if(default_socket.length() > sizeof(myaddr.sun_path) - 1) {
                 log_error() << "default socket path too long for sun_path" << endl;	
             }
-            if (-1 == unlink(myaddr.sun_path)){
+            if (-1 == unlink(myaddr.sun_path) && errno != ENOENT){
                 log_perror("unlink failed") << "\t" << myaddr.sun_path << endl;
             }
             old_umask = umask(0);
@@ -630,7 +630,7 @@ bool Daemon::setup_listen_fds()
                 if(socket_path.length() > sizeof(myaddr.sun_path) - 1) {
                     log_error() << "$HOME/.iceccd.socket path too long for sun_path" << endl;
                 }
-                if (-1 == unlink(myaddr.sun_path)){
+                if (-1 == unlink(myaddr.sun_path) && errno != ENOENT){
                     log_perror("unlink failed") << "\t" << myaddr.sun_path << endl;
                 }
             } else {
@@ -645,7 +645,7 @@ bool Daemon::setup_listen_fds()
         if(test_socket.length() > sizeof(myaddr.sun_path) - 1) {
             log_error() << "$ICECC_TEST_SOCKET path too long for sun_path" << endl;
         }
-        if (-1 == unlink(myaddr.sun_path)){
+        if (-1 == unlink(myaddr.sun_path) && errno != ENOENT){
             log_perror("unlink failed") << "\t" << myaddr.sun_path << endl;
         }
     }

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -441,6 +441,7 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
                         job_stat[JobStatistics::in_compressed] += fcmsg->compressed;
                     } else {
                         log_error() << "protocol error while reading preprocessed file" << endl;
+                        input_complete = true;
                         return_value = EXIT_IO_ERROR;
                         client_fd = -1;
                         kill(pid, SIGTERM);
@@ -451,6 +452,7 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
                 }
             } else if (client->at_eof()) {
                 log_error() << "unexpected EOF while reading preprocessed file" << endl;
+                input_complete = true;
                 return_value = EXIT_IO_ERROR;
                 client_fd = -1;
                 kill(pid, SIGTERM);

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -2352,7 +2352,7 @@ int main(int argc, char *argv[])
     if ((-1 == close(broad_fd)) && (errno != EBADF)){
         log_perror("close failed");
     }
-    if (-1 == unlink(pidFilePath.c_str())){
+    if (-1 == unlink(pidFilePath.c_str()) && errno != ENOENT){
         log_perror("unlink failed") << "\t" << pidFilePath << endl;
     }
     return 0;

--- a/services/comm.cpp
+++ b/services/comm.cpp
@@ -192,7 +192,7 @@ bool MsgChannel::update_state(void)
         if (instate != NEED_LEN) {
             break;
         }
-
+        // fallthrough
     case NEED_LEN:
 
         if (text_based) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -36,7 +36,7 @@ clangplugin: ${builddir}/clangplugin.so
 # in configure (and it is, as icecream uses static libs). So just do it manually. If this matters
 # for anybody, feel free to do this in a better way.
 ${builddir}/clangplugin.so: clangplugin.cpp
-	$(CXX) -shared -fPIC -o $@ $^ -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fno-rtti
+	$(CLANGXX) -shared -fPIC -o $@ $^ $(LLVM_CXXFLAGS)
 
 clean: clean-clangplugin
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,6 +30,7 @@ test-run-strict: test-setup.sh
 test-run: @HAVE_CLANG_DEVEL_DEP@
 test-run-strict: @HAVE_CLANG_DEVEL_DEP@
 
+.PHONY: clangplugin
 clangplugin: ${builddir}/clangplugin.so
 
 # It appears there's no way to force libtool to create a shared library if AC_DISABLE_SHARED is used

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,7 +13,7 @@ test-prepare:
 test-full: test-prepare
 	$(MAKE) test-run
 
-test-run:
+test-run: test-setup.sh
 	results=`realpath -s ${builddir}/results` && builddir2=`realpath -s ${builddir}` && cd ${srcdir} && ./test.sh ${prefix} $$results --builddir=$$builddir2
 
 # Automake's conditionals are dumb and adding 'test-run: clangplugin' would make it warn about
@@ -40,3 +40,5 @@ testargs_LDADD = ../client/libclient.a ../services/libicecc.la $(LIBRSYNC)
 
 check_PROGRAMS = testargs
 testargs_SOURCES = args.cpp
+
+check_SCRIPTS = test.sh test-setup.sh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,8 @@
+# By default be lenient and don't fail if some tests are skipped.
+# Strict mode will fail in such case.
+
 test: test-full
+test-strict: test-full-strict
 
 test-prepare:
 	if test -x /sbin/setcap; then \
@@ -13,12 +17,18 @@ test-prepare:
 test-full: test-prepare
 	$(MAKE) test-run
 
+test-full-strict: test-prepare
+	$(MAKE) test-run-strict
+
 test-run: test-setup.sh
 	results=`realpath -s ${builddir}/results` && builddir2=`realpath -s ${builddir}` && cd ${srcdir} && ./test.sh ${prefix} $$results --builddir=$$builddir2
+test-run-strict: test-setup.sh
+	results=`realpath -s ${builddir}/results` && builddir2=`realpath -s ${builddir}` && cd ${srcdir} && ./test.sh ${prefix} $$results --builddir=$$builddir2 --strict
 
 # Automake's conditionals are dumb and adding 'test-run: clangplugin' would make it warn about
 # being defined in two contexts, even though in this context it's harmless and intended.
 test-run: @HAVE_CLANG_DEVEL_DEP@
+test-run-strict: @HAVE_CLANG_DEVEL_DEP@
 
 clangplugin: ${builddir}/clangplugin.so
 

--- a/tests/includes.h
+++ b/tests/includes.h
@@ -1,7 +1,7 @@
 #ifndef INCLUDES_H
 #define INCLUDES_H
 
-#include <stdlib.h>
+#include <string.h>
 #include <iostream>
 
 #endif

--- a/tests/test-setup.sh.in
+++ b/tests/test-setup.sh.in
@@ -1,0 +1,4 @@
+# Sourced by test.sh , not to be used directly.
+
+# Needed for locating our compiler wrapper symlinks.
+pkglibexecdir=@PKGLIBEXECDIR@

--- a/tests/test-setup.sh.in
+++ b/tests/test-setup.sh.in
@@ -2,3 +2,7 @@
 
 # Needed for locating our compiler wrapper symlinks.
 pkglibexecdir=@PKGLIBEXECDIR@
+
+# Hardcoded paths to the actual compilers.
+CLANG=@CLANG@
+CLANGXX=@CLANGXX@

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -977,27 +977,24 @@ if test -z "$chroot_disabled"; then
     make_test 2
 fi
 
-if test -z "$debug_fission_disabled"; then
-    run_ice "$testdir/plain.o" "remote" 0 "split_dwarf" $GXX -Wall -Werror -gsplit-dwarf -g -c plain.cpp -o "$testdir/"plain.o
-fi
 run_ice "$testdir/plain.o" "remote" 0 $GXX -Wall -Werror -c plain.cpp -o "$testdir/"plain.o
 
-if test -z "$debug_fission_disabled"; then
-    run_ice "$testdir/plain.o" "remote" 0 "split_dwarf" $GCC -Wall -Werror -gsplit-dwarf -c plain.c -o "$testdir/"plain.o
-    run_ice "$testdir/plain.o" "remote" 0 "split_dwarf" $GCC -Wall -Werror -gsplit-dwarf -c plain.c -o "../../../../../../../..$testdir/plain.o"
-fi
 run_ice "$testdir/plain.o" "remote" 0 $GCC -Wall -Werror -c plain.c -o "$testdir/"plain.o
 run_ice "$testdir/plain.o" "remote" 0 $GXX -Wall -Werror -c plain.cpp -O2 -o "$testdir/"plain.o
 run_ice "$testdir/plain.ii" "local" 0 $GXX -Wall -Werror -E plain.cpp -o "$testdir/"plain.ii
 run_ice "$testdir/includes.o" "remote" 0 $GXX -Wall -Werror -c includes.cpp -o "$testdir"/includes.o
 run_ice "$testdir/plain.o" "local" 0 $GXX -Wall -Werror -c plain.cpp -mtune=native -o "$testdir"/plain.o
 run_ice "$testdir/plain.o" "remote" 0 $GCC -Wall -Werror -x c++ -c plain -o "$testdir"/plain.o
-if test -z "$debug_fission_disabled"; then
-    run_ice "" "remote" 300 "split_dwarf" $GXX -gsplit-dwarf -c nonexistent.cpp
-fi
 
 run_ice "" "remote" 300 $GXX -c nonexistent.cpp
 run_ice "" "local" 0 /bin/true
+
+if test -z "$debug_fission_disabled"; then
+    run_ice "$testdir/plain.o" "remote" 0 "split_dwarf" $GXX -Wall -Werror -gsplit-dwarf -g -c plain.cpp -o "$testdir/"plain.o
+    run_ice "$testdir/plain.o" "remote" 0 "split_dwarf" $GCC -Wall -Werror -gsplit-dwarf -c plain.c -o "$testdir/"plain.o
+    run_ice "$testdir/plain.o" "remote" 0 "split_dwarf" $GCC -Wall -Werror -gsplit-dwarf -c plain.c -o "../../../../../../../..$testdir/plain.o"
+    run_ice "" "remote" 300 "split_dwarf" $GXX -gsplit-dwarf -c nonexistent.cpp
+fi
 
 if $GXX -E -fdiagnostics-show-caret messages.cpp >/dev/null 2>/dev/null; then
     # gcc stderr workaround, icecream will force a local recompile

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -86,7 +86,10 @@ fi
 
 abort_tests()
 {
-    for logfile in "$testdir"/*.log*; do
+    for logfile in "$testdir"/*.log; do
+        if [[ $logfile == *_all.log ]]; then
+            continue
+        fi
         echo "Log file: ${logfile}"
         cat ${logfile}
     done

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1139,6 +1139,8 @@ if test -x $CLANGXX; then
         check_log_message stderr "warning: unused variable 'unused'"
         rm "$testdir"/messages.o
     else
+        echo Clang does not provide functional -frewrite-includes, skipping test.
+        echo
         skipped_tests="$skipped_tests clang_rewrite_includes"
     fi
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -860,7 +860,7 @@ reset_logs()
     shift
     # in case icecc.log or stderr.log don't exit, avoid error message
     touch "$testdir"/icecc.log "$testdir"/stderr.log
-    for log in scheduler localice remoteice1 remoteice2 icecc stderr; do
+    for log in scheduler localice remoteice1 remoteice2 icecc stderr iceccdstderr_localice iceccdstderr_remoteice1 iceccdstderr_remoteice2; do
         # save (append) previous log
         cat "$testdir"/${log}.log >> "$testdir"/${log}_all.log
         # and start a new one
@@ -957,12 +957,18 @@ rm -f "$testdir"/remoteice1_all.log
 rm -f "$testdir"/remoteice2_all.log
 rm -f "$testdir"/icecc_all.log
 rm -f "$testdir"/stderr_all.log
+rm -f "$testdir"/iceccdstderr_localice_all.log
+rm -f "$testdir"/iceccdstderr_remoteice1_all.log
+rm -f "$testdir"/iceccdstderr_remoteice2_all.log
 echo -n >"$testdir"/scheduler.log
 echo -n >"$testdir"/localice.log
 echo -n >"$testdir"/remoteice1.log
 echo -n >"$testdir"/remoteice2.log
 echo -n >"$testdir"/icecc.log
 echo -n >"$testdir"/stderr.log
+echo -n >"$testdir"/iceccdstderr_localice.log
+echo -n >"$testdir"/iceccdstderr_remoteice1.log
+echo -n >"$testdir"/iceccdstderr_remoteice2.log
 
 echo Starting icecream.
 stop_ice 2

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -6,10 +6,11 @@ shift
 shift
 valgrind=
 builddir=.
+strict=
 
 usage()
 {
-    echo Usage: "$0 <install_prefix> <testddir> [--builddir=dir] [--valgrind[=command]]"
+    echo Usage: "$0 <install_prefix> <testddir> [--builddir=dir] [--valgrind[=command]] [--strict]"
     exit 3
 }
 
@@ -25,6 +26,9 @@ while test -n "$1"; do
             ;;
         --builddir=*)
             builddir=`echo $1 | sed 's/^--builddir=//'`
+            ;;
+        --strict)
+            strict=1
             ;;
         *)
             usage
@@ -1154,8 +1158,15 @@ if test -n "$valgrind"; then
 fi
 
 if test -n "$skipped_tests"; then
-    echo "All tests OK, some were skipped:$skipped_tests"
-    echo =============
+    if test -n "$strict"; then
+        echo "All executed tests passed, but some were skipped:$skipped_tests"
+        echo "Strict mode enabled, failing."
+        echo ==================================================
+        exit 1
+    else
+        echo "All tests OK, some were skipped:$skipped_tests"
+        echo =================================
+    fi
 else
     echo All tests OK.
     echo =============

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -308,7 +308,9 @@ run_ice()
     fi
     split_dwarf=
     if test "$1" = "split_dwarf"; then
-        split_dwarf=$(echo $output | sed 's/\.[^.]*//g').dwo
+        if test -n "$output"; then
+            split_dwarf=$(echo $output | sed 's/\.[^.]*//g').dwo
+        fi
         shift
     fi
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -414,13 +414,19 @@ run_ice()
         abort_tests
     fi
     if ! diff -q "$testdir"/stderr.localice "$testdir"/stderr; then
-        echo "Stderr mismatch ($"testdir"/stderr.localice)"
+        echo "Stderr mismatch ($testdir/stderr.localice)"
+        echo ================
+        diff -u "$testdir"/stderr "$testdir"/stderr.localice
+        echo ================
         stop_ice 0
         abort_tests
     fi
     if test -z "$chroot_disabled"; then
         if ! diff -q "$testdir"/stderr.remoteice "$testdir"/stderr; then
-            echo "Stderr mismatch ($"testdir"/stderr.remoteice)"
+            echo "Stderr mismatch ($testdir/stderr.remoteice)"
+            echo ================
+            diff -u "$testdir"/stderr "$testdir"/stderr.remoteice
+            echo ================
             stop_ice 0
             abort_tests
         fi
@@ -442,6 +448,9 @@ run_ice()
                 -e "$remove_size_of_area" > "$output".local.readelf.txt || cp "$output" "$output".local.readelf.txt
             if ! diff -q "$output".local.readelf.txt "$output".readelf.txt; then
                 echo "Output mismatch ($output.localice)"
+                echo ================
+                diff -u "$output".readelf.txt "$output".local.readelf.txt
+                echo ================
                 stop_ice 0
                 abort_tests
             fi
@@ -452,6 +461,9 @@ run_ice()
                     -e "$remove_size_of_area" > "$output".remote.readelf.txt || cp "$output" "$output".remote.readelf.txt
                 if ! diff -q "$output".remote.readelf.txt "$output".readelf.txt; then
                     echo "Output mismatch ($output.remoteice)"
+                    echo ================
+                    diff -u "$output".readelf.txt "$output".remote.readelf.txt
+                    echo ================
                     stop_ice 0
                     abort_tests
                 fi
@@ -459,12 +471,18 @@ run_ice()
         else
             if ! diff -q "$output".localice "$output"; then
                 echo "Output mismatch ($output.localice)"
+                echo ================
+                diff -u "$output" "$output".localice
+                echo ================
                 stop_ice 0
                 abort_tests
             fi
             if test -z "$chroot_disabled"; then
                 if ! diff -q "$output".remoteice "$output"; then
                     echo "Output mismatch ($output.remoteice)"
+                    echo ================
+                    diff -u "$output" "$output".remoteice
+                    echo ================
                     stop_ice 0
                     abort_tests
                 fi
@@ -478,6 +496,9 @@ run_ice()
             sed -e $remove_debug_info -e "$remove_offset_number" > "$split_dwarf".local.readelf.txt || cp "$split_dwarf" "$split_dwarf".local.readelf.txt
         if ! diff -q "$split_dwarf".local.readelf.txt "$split_dwarf".readelf.txt; then
             echo "Output DWO mismatch ($split_dwarf.localice)"
+            echo ====================
+            diff -u "$split_dwarf".readelf.txt "$split_dwarf".local.readelf.txt
+            echo ====================
             stop_ice 0
             abort_tests
         fi
@@ -486,6 +507,9 @@ run_ice()
                 sed -e "$remove_debug_info" -e "$remove_offset_number" > "$split_dwarf".remote.readelf.txt || cp "$split_dwarf" "$split_dwarf".remote.readelf.txt
             if ! diff -q "$split_dwarf".remote.readelf.txt "$split_dwarf".readelf.txt; then
                 echo "Output DWO mismatch ($split_dwarf.remoteice)"
+                echo ====================
+                diff -u "$split_dwarf".readelf.txt "$split_dwarf".remote.readelf.txt
+                echo ====================
                 stop_ice 0
                 abort_tests
             fi
@@ -791,11 +815,17 @@ debug_test()
 
     if ! diff -q "$testdir"/debug-output-local.txt "$testdir"/debug-output-remote.txt ; then
         echo Gdb output different.
+        echo =====================
+        diff -u "$testdir"/debug-output-local.txt "$testdir"/debug-output-remote.txt
+        echo =====================
         stop_ice 0
         abort_tests
     fi
     if ! diff -q "$testdir"/readelf-local.txt "$testdir"/readelf-remote.txt ; then
         echo Readelf output different.
+        echo =====================
+        diff -u "$testdir"/readelf-local.txt "$testdir"/readelf-remote.txt
+        echo =====================
         stop_ice 0
         abort_tests
     fi

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -313,7 +313,7 @@ run_ice()
     fi
 
     if [[ $expected_exit -gt 128 ]]; then
-        $@
+        $@ 2>/dev/null
         expected_exit=$?
     fi
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -80,8 +80,7 @@ unset ICECC_CARET_WORKAROUND
 
 GCC=/usr/bin/gcc
 GXX=/usr/bin/g++
-CLANG=/usr/bin/clang
-CLANGXX=/usr/bin/clang++
+# CLANG,CLANGXX set up by test-setup.h
 
 mkdir -p "$testdir"
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1014,11 +1014,11 @@ fi
 if command -v gdb >/dev/null; then
     if command -v readelf >/dev/null; then
         debug_test "$GXX" "-c -g debug.cpp" "Temporary breakpoint 1, main () at debug.cpp:8"
+        debug_test "$GXX" "-c -g `pwd`/debug/debug2.cpp" "Temporary breakpoint 1, main () at `pwd`/debug/debug2.cpp:8"
         if test -z "$debug_fission_disabled"; then
             debug_test "$GXX" "-c -g debug.cpp -gsplit-dwarf" "Temporary breakpoint 1, main () at debug.cpp:8"
             debug_test "$GXX" "-c -g `pwd`/debug/debug2.cpp -gsplit-dwarf" "Temporary breakpoint 1, main () at `pwd`/debug/debug2.cpp:8"
         fi
-        debug_test "$GXX" "-c -g `pwd`/debug/debug2.cpp" "Temporary breakpoint 1, main () at `pwd`/debug/debug2.cpp:8"
     fi
 else
     skipped_tests="$skipped_tests debug"
@@ -1072,11 +1072,11 @@ if test -x $CLANGXX; then
     if command -v gdb >/dev/null; then
         if command -v readelf >/dev/null; then
             debug_test "$CLANGXX" "-c -g debug.cpp" "Temporary breakpoint 1, main () at debug.cpp:8"
+            debug_test "$CLANGXX" "-c -g `pwd`/debug/debug2.cpp" "Temporary breakpoint 1, main () at `pwd`/debug/debug2.cpp:8"
             if test -z "$clang_debug_fission_disabled"; then
                 debug_test "$CLANGXX" "-c -g debug.cpp -gsplit-dwarf" "Temporary breakpoint 1, main () at debug.cpp:8"
                 debug_test "$CLANGXX" "-c -g `pwd`/debug/debug2.cpp -gsplit-dwarf" "Temporary breakpoint 1, main () at `pwd`/debug/debug2.cpp:8"
             fi
-            debug_test "$CLANGXX" "-c -g `pwd`/debug/debug2.cpp" "Temporary breakpoint 1, main () at `pwd`/debug/debug2.cpp:8"
         fi
     fi
 


### PR DESCRIPTION
These commits make the clang tests build properly/better. This includes some hacks for Travis builds, as it's actually non-trivial to get it to build there. Ubuntu 14.04 apparently ships clang 3.4 as /usr/bin/clang, and icecream in some places still has this path hardcoded. That should indeed get fixed somewhen, but this works for now.

Note that this is only 5 commits, the rest are the same as in my other pull request.
