### PR TITLE
detect gcc more reliably when running tests

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -134,7 +134,7 @@ check_compilers()
         fi
     fi
     using_gcc=
-    if $TESTCC --version | grep gcc >/dev/null; then
+    if $TESTCC -v 2>&1 | grep ^gcc >/dev/null; then
         using_gcc=1
     fi
     using_clang=


### PR DESCRIPTION
If cc is a symlink to gcc, then "cc --version" refers to cc instead of gcc,
then tests are run without using_gcc=1. So let's grep for gcc in the output
of "$TESTCC -v" instead.