### PR TITLE
compile fixes for ubuntu 17.10 / GCC 7.2.0

### DIFF
--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -52,6 +52,7 @@
 #include "../services/comm.h"
 #include "../services/logging.h"
 #include "../services/job.h"
+#include "../services/util.h"
 #include "config.h"
 
 #include "compileserver.h"
@@ -1798,7 +1799,7 @@ static void trigger_exit(int signum)
     } else {
         // hmm, we got killed already. try better
         static const char msg[] = "forced exit.\n";
-        write(STDERR_FILENO, msg, strlen( msg ));
+        ignore_result(write(STDERR_FILENO, msg, strlen( msg )));
         _exit(1);
     }
 
@@ -2016,7 +2017,10 @@ int main(int argc, char *argv[])
     log_info() << "ICECREAM scheduler " VERSION " starting up, port " << scheduler_port << endl;
 
     if (detach) {
-        daemon(0, 0);
+        if (daemon(0, 0) != 0) {
+            log_errno("Error: failed to detach.", errno);
+            exit(1);
+        }
     }
 
     listen_fd = open_tcp_listener(scheduler_port);


### PR DESCRIPTION
This avoids a couple of warn_unused_result compile errors on Ubuntu 17.10 (which aren't silenced by simply casting to void):

scheduler.cpp: In function ‘int main(int, char**)’:
scheduler.cpp:2019:15: warning: ignoring return value of ‘int daemon(int, int)’, declared with attribute warn_unused_result [-Wunused-result]
         daemon(0, 0);
         ~~~~~~^~~~~~
scheduler.cpp: In function ‘void trigger_exit(int)’:
scheduler.cpp:1801:14: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
         write(STDERR_FILENO, msg, strlen( msg ));
         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~