### PR TITLE
relax the ASAN test so that it passes on Ubuntu 16.04

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1531,7 +1531,7 @@ if $TESTCXX -fsanitize=address -c -fsyntax-only -Werror fsanitize.cpp >/dev/null
     check_log_message stderr "ERROR: AddressSanitizer: heap-use-after-free"
     # Only newer versions of ASAN have the SUMMARY line.
     if grep -q "^SUMMARY:" "$testdir"/stderr.log; then
-        check_log_message stderr "SUMMARY: AddressSanitizer: heap-use-after-free .*fsanitize.cpp:5.* in test_fsanitize_function()"
+        check_log_message stderr "SUMMARY: AddressSanitizer: heap-use-after-free .*fsanitize.cpp:5.* test_fsanitize_function()"
     fi
     rm "$testdir"/fsanitize.o
 


### PR DESCRIPTION
For some reason, the ASAN setup on Ubuntu 16.04 lacks proper symbols.
This patch relaxes the ASAN test a little, so that it passes in this
environment.

Ubuntu 17.10 does not require this fix, I'm not sure of the status on
17.04.