### PR TITLE
explicitly run test.sh with bash, don't rely on the #! line

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,7 +20,7 @@ test-full: test-prepare
 	$(MAKE) test-run
 
 test-run: test-setup.sh
-	results=`realpath -s ${builddir}/results` && builddir2=`realpath -s ${builddir}` && cd ${srcdir} && ./test.sh ${prefix} $$results --builddir=$$builddir2 --strict=$(STRICT) --valgrind=$(VALGRIND)
+	results=`realpath -s ${builddir}/results` && builddir2=`realpath -s ${builddir}` && cd ${srcdir} && /bin/bash test.sh ${prefix} $$results --builddir=$$builddir2 --strict=$(STRICT) --valgrind=$(VALGRIND)
 
 TESTS = testargs
 


### PR DESCRIPTION
This makes it easier to work on the test suite, since it avoids "bad interpreter: Text file busy" errors if you have the script open in an editor when trying to run it.