### PR TITLE
removed unused `guess` calculation from pick_server()

### DIFF
--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -576,18 +576,6 @@ static CompileServer *pick_server(Job *job)
         return 0;
     }
 
-    /* Now guess about the job.  First see, if this submitter already
-       had other jobs.  Use them as base.  */
-    JobStat guess;
-
-    if (job->submitter()->lastRequestedJobs().size() > 0) {
-        guess = job->submitter()->cumRequested()
-                / job->submitter()->lastRequestedJobs().size();
-    } else {
-        /* Otherwise simply average over all jobs.  */
-        guess = cum_job_stats / all_job_stats.size();
-    }
-
     CompileServer *best = 0;
     // best uninstalled
     CompileServer *bestui = 0;


### PR DESCRIPTION
This value has never been used, since it was added to the codebase in
34cbeae30d70fca16ac467757c4507a6c2a16639.

Resolves #155.