### PR TITLE
[codacy] fix printf format code

### DIFF
--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -315,7 +315,7 @@ static void handle_monitor_stats(CompileServer *cs, StatsMsg *m = 0)
         sprintf(buffer, "FreeMem:%d\n", m->freeMem);
         msg += buffer;
     } else {
-        sprintf(buffer, "Load:%d\n", cs->load());
+        sprintf(buffer, "Load:%u\n", cs->load());
         msg += buffer;
     }
 


### PR DESCRIPTION
This should fix the following codacy issue:
%d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.