### PR TITLE
[codacy] initialise more values in CPULoadInfo constructor

### DIFF
--- a/daemon/load.cpp
+++ b/daemon/load.cpp
@@ -78,6 +78,11 @@ struct CPULoadInfo {
     load_t waitTicks;
 
     CPULoadInfo() {
+        userLoad = 0;
+        niceLoad = 0;
+        sysLoad = 0;
+        idleLoad = 0;
+
         userTicks = 0;
         niceTicks = 0;
         sysTicks = 0;


### PR DESCRIPTION
This should hopefully fix the following codacy issue:
Member variable 'CPULoadInfo::userLoad' is not initialized in the constructor.