### PR TITLE
[codacy] fix printf format code in handle_connection

### DIFF
--- a/daemon/serve.cpp
+++ b/daemon/serve.cpp
@@ -209,7 +209,7 @@ int handle_connection(const string &basedir, CompileJob *job,
 
         char *tmp_output = 0;
         char prefix_output[32]; // 20 for 2^64 + 6 for "icecc-" + 1 for trailing NULL
-        sprintf(prefix_output, "icecc-%d", job_id);
+        sprintf(prefix_output, "icecc-%u", job_id);
 
         if (job->dwarfFissionEnabled() && (ret = dcc_make_tmpdir(&tmp_output)) == 0) {
             tmp_path = tmp_output;


### PR DESCRIPTION
This should fix the following codacy issue:
%d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.