### PR TITLE
[codacy] remove unneeded null-after-delete

### DIFF
--- a/daemon/serve.cpp
+++ b/daemon/serve.cpp
@@ -313,7 +313,6 @@ int handle_connection(const string &basedir, CompileJob *job,
 
     } catch (const myexception& e) {
         delete client;
-        client = 0;
 
         if (!obj_file.empty()) {
             if (-1 == unlink(obj_file.c_str()) && errno != ENOENT){


### PR DESCRIPTION
This should fix the following codacy issue:
Assignment of function parameter has no effect outside the function. Did you forget dereferencing it?