### PR TITLE
require C++11 to build icecc

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 1.2 (in progress)
+ - C++11 is required to build icecc
 
 1.1
  - revert "Add load control for preprocessing"

--- a/README
+++ b/README
@@ -6,6 +6,8 @@ form of process accounting in there.
 How to install icecream
 =======================
 
+You must have a compiler that supports C++11.
+
 cd icecream
 ./autogen.sh
 ./configure --prefix=/opt/icecream

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,8 @@ AM_INIT_AUTOMAKE([1.11 foreign dist-bzip2])
 AM_SILENT_RULES([yes])
 AC_LANG([C++])
 
+CXXFLAGS="-std=c++11 $CXXFLAGS"
+
 # ===========================
 # Find required base packages
 # ===========================

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -581,7 +581,7 @@ bool Daemon::setup_listen_fds()
             myaddr.sin_port = htons(daemon_port);
             myaddr.sin_addr.s_addr = INADDR_ANY;
 
-            if (bind(tcp_listen_fd, (struct sockaddr *)&myaddr,
+            if (::bind(tcp_listen_fd, (struct sockaddr *)&myaddr,
                      sizeof(myaddr)) < 0) {
                 log_perror("bind()");
                 sleep(2);
@@ -665,7 +665,7 @@ bool Daemon::setup_listen_fds()
         }
     }
 
-    if (bind(unix_listen_fd, (struct sockaddr*)&myaddr, sizeof(myaddr)) < 0) {
+    if (::bind(unix_listen_fd, (struct sockaddr*)&myaddr, sizeof(myaddr)) < 0) {
         log_perror("bind()");
 
         if (reset_umask) {

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -1708,7 +1708,7 @@ static int open_broad_listener(int port)
     myaddr.sin_port = htons(port);
     myaddr.sin_addr.s_addr = INADDR_ANY;
 
-    if (bind(listen_fd, (struct sockaddr *) &myaddr, sizeof(myaddr)) < 0) {
+    if (::bind(listen_fd, (struct sockaddr *) &myaddr, sizeof(myaddr)) < 0) {
         log_perror("bind()");
         return -1;
     }
@@ -1745,7 +1745,7 @@ static int open_tcp_listener(short port)
     myaddr.sin_port = htons(port);
     myaddr.sin_addr.s_addr = INADDR_ANY;
 
-    if (bind(fd, (struct sockaddr *) &myaddr, sizeof(myaddr)) < 0) {
+    if (::bind(fd, (struct sockaddr *) &myaddr, sizeof(myaddr)) < 0) {
         log_perror("bind()");
         return -1;
     }


### PR DESCRIPTION
We can modernise the icecc codebase a bit now that icecc 1.1 has
been released.

GCC >= 4.8 and Clang >= 3.3 officially support C++11. Most currently
supported Linux distribution releases either have such a compiler by
default, or as an optional install:

Ubuntu 14.04 LTS has GCC 4.9
Ubuntu 16.04 LTS has GCC 5.3
Debian Stretch has GCC 6.3
openSUSE Leap 42.2 has GCC 6.1.1
Red Hat Enterprise Linux 6 has a "Red Hat Developer Toolset" backport of GCC 6.2
SUSE Linux Enterprise 11 SP4 has an optional GCC 5.2 toolchain

Resolves #353