### PR TITLE
fix path canonicalization functions

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -34,6 +34,7 @@
 #include <sys/stat.h>
 
 #include "client.h"
+#include "file_util.h"
 
 using namespace std;
 
@@ -591,7 +592,7 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                 string file = a + strlen(prefix);
 
                 if (access(file.c_str(), R_OK) == 0) {
-                    file = get_absfilename(file);
+                    file = get_abs_path(file);
                     extrafiles->push_back(file);
                 } else {
                     always_local = true;
@@ -611,7 +612,7 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                             string file = argv[i + 2];
 
                             if (access(file.c_str(), R_OK) == 0) {
-                                file = get_absfilename(file);
+                                file = get_abs_path(file);
                                 extrafiles->push_back(file);
                             } else {
                                 always_local = true;

--- a/client/client.h
+++ b/client/client.h
@@ -34,14 +34,12 @@
 
 #include "exitcode.h"
 #include "logging.h"
+#include "file_util.h"
 #include "util.h"
 
 class MsgChannel;
 
 extern std::string remote_daemon;
-
-/* in remote.cpp */
-extern std::string get_absfilename(const std::string &_file);
 
 /* In arg.cpp.  */
 extern bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun,

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -59,6 +59,7 @@
 
 #include "client.h"
 #include "platform.h"
+#include "file_util.h"
 #include "util.h"
 #include "argv.h"
 
@@ -385,7 +386,7 @@ int main(int argc, char **argv)
                 file = string(extrafilesenv, colon - extrafilesenv);
             }
 
-            file = get_absfilename(file);
+            file = get_abs_path(file);
 
             struct stat st;
             if (stat(file.c_str(), &st) == 0) {
@@ -495,7 +496,7 @@ int main(int argc, char **argv)
         Msg *startme = 0L;
 
         /* Inform the daemon that we like to start a job.  */
-        if (local_daemon->send_msg(JobLocalBeginMsg(0, get_absfilename(job.outputFile())))) {
+        if (local_daemon->send_msg(JobLocalBeginMsg(0, get_abs_path(job.outputFile())))) {
             /* Now wait until the daemon gives us the start signal.  40 minutes
                should be enough for all normal compile or link jobs.  */
             startme = local_daemon->get_msg(40 * 60);

--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -52,6 +52,7 @@
 #include "tempfile.h"
 #include "md5.h"
 #include "util.h"
+#include "services/file_util.h"
 #include "services/util.h"
 
 #ifndef O_LARGEFILE
@@ -179,46 +180,6 @@ rip_out_paths(const Environments &envs, map<string, string> &version_map, map<st
     }
 
     return env2;
-}
-
-
-string
-get_absfilename(const string &_file)
-{
-    string file;
-
-    if (_file.empty()) {
-        return _file;
-    }
-
-    if (_file.at(0) != '/') {
-        file = get_cwd() + '/' + _file;
-    } else {
-        file = _file;
-    }
-
-    string::size_type idx = file.find("/..");
-
-    while (idx != string::npos) {
-        file.replace(idx, 3, "/");
-        idx = file.find("/..");
-    }
-
-    idx = file.find("/./");
-
-    while (idx != string::npos) {
-        file.replace(idx, 3, "/");
-        idx = file.find("/./");
-    }
-
-    idx = file.find("//");
-
-    while (idx != string::npos) {
-        file.replace(idx, 2, "/");
-        idx = file.find("//");
-    }
-
-    return file;
 }
 
 static UseCSMsg *get_server(MsgChannel *local_daemon)
@@ -795,7 +756,7 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
             fake_filename += "/" + *it;
         }
 
-        fake_filename += get_absfilename(job.inputFile());
+        fake_filename += get_abs_path(job.inputFile());
 
         GetCSMsg getcs(envs, fake_filename, job.language(), torepeat,
                        job.targetPlatform(), job.argumentFlags(),
@@ -845,7 +806,7 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
         sprintf(rand_seed, "-frandom-seed=%d", rand());
         job.appendFlag(rand_seed, Arg_Remote);
 
-        GetCSMsg getcs(envs, get_absfilename(job.inputFile()), job.language(), torepeat,
+        GetCSMsg getcs(envs, get_abs_path(job.inputFile()), job.language(), torepeat,
                        job.targetPlatform(), job.argumentFlags(),
                        preferred_host ? preferred_host : string(),
                        minimalRemoteVersion(job));

--- a/client/util.cpp
+++ b/client/util.cpp
@@ -354,21 +354,6 @@ int resolve_link(const std::string &file, std::string &resolved)
     return 0;
 }
 
-std::string get_cwd()
-{
-    static std::vector<char> buffer(1024);
-
-    errno = 0;
-    while (getcwd(&buffer[0], buffer.size() - 1) == 0 && errno == ERANGE) {
-        buffer.resize(buffer.size() + 1024);
-        errno = 0;
-    }
-    if (errno != 0)
-        return std::string();
-
-    return string(&buffer[0]);
-}
-
 std::string read_command_output(const std::string& command)
 {
     FILE *f = popen(command.c_str(), "r");

--- a/client/util.h
+++ b/client/util.h
@@ -36,7 +36,6 @@ extern bool compiler_has_color_output(const CompileJob &job);
 extern bool output_needs_workaround(const CompileJob &job);
 extern bool ignore_unverified();
 extern int resolve_link(const std::string &file, std::string &resolved);
-extern std::string get_cwd();
 extern std::string read_command_output(const std::string& command);
 
 extern bool dcc_unlock(int lock_fd);

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -6,8 +6,7 @@ iceccd_SOURCES = \
 	serve.cpp \
 	workit.cpp \
 	environment.cpp \
-	load.cpp \
-	file_util.cpp
+	load.cpp
 
 iceccd_LDADD = \
 	../services/libicecc.la \
@@ -22,5 +21,4 @@ noinst_HEADERS = \
 	load.h \
 	ncpus.h \
 	serve.h \
-	workit.h \
-	file_util.h
+	workit.h

--- a/services/Makefile.am
+++ b/services/Makefile.am
@@ -1,5 +1,15 @@
 lib_LTLIBRARIES = libicecc.la
-libicecc_la_SOURCES = job.cpp comm.cpp exitcode.cpp getifaddrs.cpp logging.cpp tempfile.c platform.cpp gcc.cpp
+libicecc_la_SOURCES = \
+	job.cpp \
+	comm.cpp \
+	exitcode.cpp \
+	file_util.cpp \
+	getifaddrs.cpp \
+	logging.cpp \
+	tempfile.c \
+	platform.cpp \
+	gcc.cpp
+
 libicecc_la_LIBADD = \
 	$(LZO_LDADD) \
 	$(CAPNG_LDADD) \
@@ -19,7 +29,8 @@ noinst_HEADERS = \
 	getifaddrs.h \
 	logging.h \
 	tempfile.h \
-	platform.h
+	platform.h \
+	file_util.h
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = icecc.pc

--- a/services/file_util.h
+++ b/services/file_util.h
@@ -27,8 +27,9 @@
 std::vector<std::string> split(const std::string &s, char delim);
 std::string get_relative_path(const std::string &to, const std::string &from);
 std::string get_canonicalized_path(const std::string &path);
+std::string get_abs_path(const std::string &path);
 bool mkpath(const std::string &path);
 bool rmpath(const char* path);
+std::string get_cwd();
 
 #endif
-


### PR DESCRIPTION
get_absfilename() doesn't handle ".." correctly:
* "/foo/../bar" -> "/foo/bar" (should be "/bar")
* "/foo/..bar" -> "/foo/bar" (should be "/foo/..bar")

Let's fix this.