### PR TITLE
Revert "Fix building with precompiled headers."

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -458,9 +458,8 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                     if (dot_index != string::npos) {
                         string ext = p.substr(dot_index + 1);
 
-                        if (ext[0] != 'h' && ext[0] != 'H'
-                            && (access(p.c_str(), R_OK)
-                                || access((p + ".gch").c_str(), R_OK))) {
+                        if (ext[0] != 'h' && ext[0] != 'H' && access(p.c_str(), R_OK)
+                            && access((p + ".gch").c_str(), R_OK)) {
                             log_info() << "include file or gch file for argument " << a << " " << p
                                        << " missing, building locally" << endl;
                             always_local = true;


### PR DESCRIPTION
This "fix" is wrong since it does exactly the opposite of what the commit
message says. The code was correct in the first place - access() will return
a false value (0) on success and a true value (-1) on error.
So if(access) has to be read as if(not_exists).

This reverts commit 5b27d706ea430ff1a42a6aec489b2790056a07d4.