### PR TITLE
Plugin alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ the tarball path is used instead of the local path to load the plugin:
 
       export ICECC_PLUGIN_ALIAS=../plugins/libFoo.so=usr/lib/libFoo.so
 
-Plugin aliases are only used when compiling with clang and has no effect
+Plugin aliases are only used when compiling with clang and have no effect
 when gcc is used as compiler.
 
 Debug output

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Table of Contents
     icecream](#cross-compiling-for-multiple-targets-in-the-same-environment-using-icecream)
 -   [How to combine icecream with
     ccache](#how-to-combine-icecream-with-ccache)
+-   [Using plugin aliases to rewrite remote plugin
+    paths](#using-plugin-aliases-to-rewrite-remote-plugin-paths)
 -   [Debug output](#debug-output)
 -   [Some Numbers](#some-numbers)
 -   [What is the best environment for
@@ -384,6 +386,36 @@ And then compile with
 Note however that ccache isn't really worth the trouble if you're not
 recompiling your project three times a day from scratch (it adds some
 overhead in comparing the source files and uses quite some disk space).
+
+Using plugin aliases to rewrite remote plugin paths
+-------------------------------------------------------------------------
+
+Plugin aliases can be used to rewrite remote plugin paths so that the
+remote compiler can load them from the unpacked tarball using different
+paths:
+
+      ICECC_PLUGIN_ALIAS=<local_name1>=<remote_name1>,<local_name2>=...
+
+When the variable ICECC_PLUGIN_ALIAS is set to a comma-separated list of
+aliases, the aliases will be used to replace local plugin paths by remote
+plugin paths.
+
+In the following example the compiler loads the plugin libFoo.so from a
+path relative to the current worktree:
+
+      clang -Xclang -load -Xclang ../plugins/libFoo.so -c bar.so
+
+Assume the plugin was added to the tarball with the following path:
+
+      usr/lib/libFoo.so
+
+The following alias definition will rewrite remote parameters so that
+the tarball path is used instead of the local path to load the plugin:
+
+      export ICECC_PLUGIN_ALIAS=../plugins/libFoo.so=usr/lib/libFoo.so
+
+Plugin aliases are only used when compiling with clang and has no effect
+when gcc is used as compiler.
 
 Debug output
 -------------------------------------------------------------------------

--- a/client/client.h
+++ b/client/client.h
@@ -44,6 +44,7 @@ extern std::string remote_daemon;
 extern std::string get_absfilename(const std::string &_file);
 
 /* In arg.cpp.  */
+extern ArgumentsList apply_plugin_aliases(const ArgumentsList& flags);
 extern bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun,
                          std::list<std::string> *extrafiles);
 

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -97,6 +97,8 @@ static void dcc_show_usage(void)
         "   ICECC_EXTRAFILES           additional files used in the compilation.\n"
         "   ICECC_COLOR_DIAGNOSTICS    set to 1 or 0 to override color diagnostics support.\n"
         "   ICECC_CARET_WORKAROUND     set to 1 or 0 to override gcc show caret workaround.\n"
+        "   ICECC_PLUGIN_ALIAS         set a comma separeted list of aliases that will be used to rewrite\n"
+        "                              remote plugin names.\n"
         "\n");
 }
 

--- a/services/job.h
+++ b/services/job.h
@@ -29,8 +29,10 @@
 #include <sstream>
 
 typedef enum {
-    Arg_Local,  // Local-only args.
-    Arg_Remote, // Remote-only args.
+    // Note that "local" here means flags that should be sent to the preprocessor
+    // and "remote" means flags that should be sent to the compiler.
+    Arg_Local,  // Local-only args. E.g. "-I" and other preprocessor flags.
+    Arg_Remote, // Remote-only args. E.g. "-target" and other code generation flags.
     Arg_Rest    // Args to use both locally and remotely.
 } Argument_Type;
 

--- a/services/job.h
+++ b/services/job.h
@@ -116,6 +116,10 @@ public:
 
     unsigned int argumentFlags() const;
 
+    const ArgumentsList& flags() const
+    {
+        return m_flags;
+    }
     void setFlags(const ArgumentsList &flags)
     {
         m_flags = flags;


### PR DESCRIPTION
The patches add support for rewriting remote paths for clang plugins using a new environment variable ICECC_PLUGIN_ALIAS. Rewriting the plugin paths are needed when clang plugins are loaded from relative paths and the same tarball should be used to build different worktrees.