### PR TITLE
added date to logging info

### DIFF
--- a/services/logging.h
+++ b/services/logging.h
@@ -59,7 +59,7 @@ static inline std::ostream &output_date(std::ostream &os)
     time_t t = time(0);
     struct tm *tmp = localtime(&t);
     char buf[64];
-    strftime(buf, sizeof(buf), "%T: ", tmp);
+    strftime(buf, sizeof(buf), "%Y-%m-%d %T: ", tmp);
 
     if (logfile_prefix.size()) {
         os << logfile_prefix;


### PR DESCRIPTION
We are often discouraged that the logs don't contain any date information, so I have modified the log mechanism to add date, not just time.