### PR TITLE
Load calculation and job distribution improvements

### DIFF
--- a/daemon/load.cpp
+++ b/daemon/load.cpp
@@ -204,11 +204,7 @@ static void updateCPULoad(CPULoadInfo *load)
         load->userLoad = (1000 * (currUserTicks - load->userTicks)) / totalTicks;
         load->sysLoad = (1000 * (currSysTicks - load->sysTicks)) / totalTicks;
         load->niceLoad = (1000 * (currNiceTicks - load->niceTicks)) / totalTicks;
-        load->idleLoad = (1000 - (load->userLoad + load->sysLoad + load->niceLoad));
-
-        if (load->idleLoad < 0) {
-            load->idleLoad = 0;
-        }
+        load->idleLoad = (1000 * (currIdleTicks - load->idleTicks)) / totalTicks;
     } else {
         load->userLoad = load->sysLoad = load->niceLoad = 0;
         load->idleLoad = 1000;

--- a/daemon/load.cpp
+++ b/daemon/load.cpp
@@ -238,7 +238,7 @@ static unsigned long int scan_one(const char *buff, const char *key)
 
 static unsigned int calculateMemLoad(unsigned long int &NetMemFree)
 {
-    unsigned long long MemFree = 0, Buffers = 0, Cached = 0;
+    unsigned long long MemTotal = 0, MemFree = 0, Buffers = 0, Cached = 0;
 
 #ifdef USE_MACH
     /* Get VM statistics. */
@@ -263,10 +263,14 @@ static unsigned int calculateMemLoad(unsigned long int &NetMemFree)
 #elif defined( USE_SYSCTL )
     size_t len = sizeof(MemFree);
 
+
+    if ((sysctlbyname("hw.physmem", &MemTotal, &len, NULL, 0) == -1) || !len) {
+        MemTotal = 0;    /* Doesn't work under FreeBSD v2.2.x */
+    }
+
     if ((sysctlbyname("vm.stats.vm.v_free_count", &MemFree, &len, NULL, 0) == -1) || !len) {
         MemFree = 0;    /* Doesn't work under FreeBSD v2.2.x */
     }
-
 
     len = sizeof(Buffers);
 
@@ -309,30 +313,31 @@ static unsigned int calculateMemLoad(unsigned long int &NetMemFree)
     }
 
     buf[n] = '\0';
+    MemTotal = scan_one(buf, "MemTotal");
     MemFree = scan_one(buf, "MemFree");
     Buffers = scan_one(buf, "Buffers");
     Cached = scan_one(buf, "Cached");
 #endif
 
-    if (Buffers > 50 * 1024) {
-        Buffers -= 50 * 1024;
+    /* Can't calculate a memory load if we don't know how much memory we have */
+    if (!MemTotal)
+        return 0;
+
+    if (Buffers > MemTotal / 100) {
+        Buffers -= MemTotal / 100;
     } else {
         Buffers /= 2;
     }
 
-    if (Cached > 50 * 1024) {
-        Cached -= 50 * 1024;
+    if (Cached > MemTotal / 100) {
+        Cached -= MemTotal / 100;
     } else {
         Cached /= 2;
     }
 
     NetMemFree = MemFree + Cached + Buffers;
 
-    if (NetMemFree > 128 * 1024) {
-        return 0;
-    }
-
-    return 1000 - (NetMemFree * 1000 / (128 * 1024));
+    return 1000 - (NetMemFree * 1000 / MemTotal);
 }
 
 // Load average calculation based on CALC_LOAD(), in the 2.6 Linux kernel

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -805,25 +805,16 @@ bool Daemon::maybe_stats(bool force_check)
             icecream_usage.tv_usec = ru.ru_utime.tv_usec;
         }
 
-        int idle_average = icecream_load;
+        unsigned int idle_average = icecream_load;
 
         if (diff_sent) {
             idle_average = icecream_load * 1000 / diff_sent;
         }
 
-        if (idle_average > 1000) {
-            idle_average = 1000;
-        }
+        if (idle_average > 1000)
+           idle_average = 1000;
 
-        msg.load = ((700 * (1000 - idle_average)) + (300 * memory_fillgrade)) / 1000;
-
-        if (memory_fillgrade > 600) {
-            msg.load = 1000;
-        }
-
-        if (idle_average < 100) {
-            msg.load = 1000;
-        }
+        msg.load = std::max((1000 - idle_average), memory_fillgrade);
 
 #ifdef HAVE_SYS_VFS_H
         struct statfs buf;

--- a/scheduler/compileserver.cpp
+++ b/scheduler/compileserver.cpp
@@ -53,6 +53,7 @@ CompileServer::CompileServer(const int fd, struct sockaddr *_addr, const socklen
     , m_chrootPossible(false)
     , m_clientCount(0)
     , m_submittedJobsCount(0)
+    , m_lastPickId(0)
     , m_compilerVersions()
     , m_lastCompiledJobs()
     , m_lastRequestedJobs()
@@ -258,12 +259,18 @@ list<Job *> CompileServer::jobList() const
 
 void CompileServer::appendJob(Job *job)
 {
+    m_lastPickId = job->id();
     m_jobList.push_back(job);
 }
 
 void CompileServer::removeJob(Job *job)
 {
     m_jobList.remove(job);
+}
+
+unsigned int CompileServer::lastPickedId()
+{
+    return m_lastPickId;
 }
 
 CompileServer::State CompileServer::state() const

--- a/scheduler/compileserver.h
+++ b/scheduler/compileserver.h
@@ -89,6 +89,7 @@ public:
     list<Job *> jobList() const;
     void appendJob(Job *job);
     void removeJob(Job *job);
+    unsigned int lastPickedId();
 
     State state() const;
     void setState(const State state);
@@ -162,6 +163,7 @@ private:
     bool m_chrootPossible;
     int m_clientCount; // number of client connections the daemon has
     int m_submittedJobsCount;
+    unsigned int m_lastPickId;
 
     Environments m_compilerVersions;  // Available compilers
 

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -688,6 +688,15 @@ static CompileServer *pick_server(Job *job)
             break;
         }
 
+        /* Distribute 5% of our jobs to servers which haven't been picked in a
+           long time. This gives us a chance to adjust the server speed rating,
+           which may change due to external influences out of our control. */
+        if (!cs->lastPickedId() ||
+            ((job->id() - cs->lastPickedId()) > (20 * css.size()))) {
+            best = cs;
+            break;
+        }
+
         if (!envs_match(cs, job).empty()) {
             if (!best) {
                 best = cs;
@@ -719,12 +728,6 @@ static CompileServer *pick_server(Job *job)
                 }
             }
         }
-    }
-
-    // to make sure we find the fast computers at least after some time, we overwrite
-    // the install rule for every 19th job - if the farm is only filled a bit
-    if (bestui && ((matches < 11) && (matches < (css.size() / 3))) && ((job->id() % 19) != 0)) {
-        best = 0;
     }
 
     if (best) {

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -305,6 +305,12 @@ static float server_speed(CompileServer *cs, Job *job, bool blockDebug)
             } else {
                 f *= float(1000 - cs->load()) / 1000;
             }
+
+            /* Gradually throttle with the number of assigned jobs. This
+             * takes care of the fact that not all slots are equally fast on
+             * CPUs with SMT and dynamic clock ramping.
+             */
+            f *= (1.0f - (0.5f * cs->jobList().size() / cs->maxJobs()));
         }
 
         // below we add a pessimism factor - assuming the first job a computer got is not representative


### PR DESCRIPTION
This pull-request does the following:
- Simplify the CPU load calculation a bit.
- Changes the memory load calculation to have an effect again (currently it would just report load 0 if there is more than 128MB of free RAM, which is very common with modern machines)
- Changes the job distribution to spread jobs a bit more if machines are roughly of the same speed, instead of fully loading the fastest machine (this works better on modern CPUs with SMT and TurboMode where the system is faster if it isn't fully loaded, but throughput still increases if enough jobs are available for distribution).
- Distribute a small number of probe jobs to clients that haven't seen a job in a while. This allows compile nodes to recover their speed rating, if they got downrated due to external influences outside of the control of icecc. Currently if the cluster is never fully loaded, build nodes with a bad speed rating never get any jobs assigned and are thus unable to get a new (possibly better) speed rating calculated.

We are running those changes internally for a while already. Exact performance numbers are hard to come up with due to a lot of noise on the cluster, but our results seem to indicate a reduction in overall build times of about 30% (use-case is mostly build of complete system rootfs via embedded build systems like ptxdist).