### PR TITLE
Fix Linux kernel build with ICECC_REMOTE_CPP

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -279,7 +279,9 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                 always_local = true;
                 args.append(a, Arg_Local);
                 log_info() << "argument " << a << ", building locally" << endl;
-            } else if (!strcmp(a, "-MD") || !strcmp(a, "-MMD")) {
+            } else if (!strcmp(a, "-MD") || !strcmp(a, "-MMD") ||
+                       str_startswith("-Wp,-MD", a) ||
+                       str_startswith("-Wp,-MMD", a)) {
                 seen_md = true;
                 args.append(a, Arg_Local);
                 /* These two generate dependencies as a side effect.  They


### PR DESCRIPTION
also handle -MD and -MMD if it passed directly to the preprocessor by using -Wp

Fixes Linux kernel build, which is using this way to pass those options. This got
broken when icecream started using -fdirectives-only for the preprocessor,
passing the CPP args to the remote. MD and MMD need to be handled at the local
side.