### PR TITLE
Keep order of compiler arguments (#424)

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -403,6 +403,7 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                 always_local = true;
                 args.append(a, Arg_Local);
             } else if (!strcmp(a, "-gsplit-dwarf")) {
+                args.append(a, Arg_RestAndDwarfFission);
                 seen_split_dwarf = true;
             } else if (str_equal(a, "-x")) {
                 args.append(a, Arg_Rest);

--- a/client/local.cpp
+++ b/client/local.cpp
@@ -251,10 +251,6 @@ int build_local(CompileJob &job, MsgChannel *local_daemon, struct rusage *used)
     arguments.push_back(compiler_name);
     appendList(arguments, job.allFlags());
 
-    if (job.dwarfFissionEnabled()) {
-        arguments.push_back("-gsplit-dwarf");
-    }
-
     if (!job.inputFile().empty()) {
         arguments.push_back(job.inputFile());
     }

--- a/daemon/serve.cpp
+++ b/daemon/serve.cpp
@@ -317,6 +317,8 @@ int handle_connection(const string &basedir, CompileJob *job,
         if (rmsg.status == 0) {
             write_output_file(obj_file, client);
             if (rmsg.have_dwo_file) {
+                // optional flag required because depending on its arguments, the
+                // compiler might not write a dwo file.
                 write_output_file(dwo_file, client, true /* optional */);
             }
         }

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -103,10 +103,9 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
     rmsg.out.erase(rmsg.out.begin(), rmsg.out.end());
     rmsg.out.erase(rmsg.out.begin(), rmsg.out.end());
 
-    std::list<string> list = j.remoteFlags();
-    appendList(list, j.restFlags());
+    std::list<string> list = j.remoteAndRestFlags();
 
-    if (j.dwarfFissionEnabled()) {
+    if(!IS_PROTOCOL_40(client) && j.dwarfFissionEnabled()) {
         list.push_back("-gsplit-dwarf");
     }
 

--- a/services/comm.h
+++ b/services/comm.h
@@ -36,7 +36,7 @@
 #include "job.h"
 
 // if you increase the PROTOCOL_VERSION, add a macro below and use that
-#define PROTOCOL_VERSION 39
+#define PROTOCOL_VERSION 40
 // if you increase the MIN_PROTOCOL_VERSION, comment out macros below and clean up the code
 #define MIN_PROTOCOL_VERSION 21
 
@@ -64,6 +64,7 @@
 #define IS_PROTOCOL_37(c) ((c)->protocol >= 37)
 #define IS_PROTOCOL_38(c) ((c)->protocol >= 38)
 #define IS_PROTOCOL_39(c) ((c)->protocol >= 39)
+#define IS_PROTOCOL_40(c) ((c)->protocol >= 40)
 
 // Terms used:
 // S  = scheduler

--- a/services/job.cpp
+++ b/services/job.cpp
@@ -28,13 +28,13 @@
 
 using namespace std;
 
-list<string> CompileJob::flags(int argumentType) const
+list<string> CompileJob::flags(Argument_Type argumentType) const
 {
     list<string> args;
 
     for (ArgumentsList::const_iterator it = m_flags.begin(); it != m_flags.end(); ++it) {
-        if (it->second & argumentType
-            || (m_dwarf_fission && (argumentType & Arg_Rest) && (it->second & Arg_RestAndDwarfFission))) {
+        if (it->second == argumentType
+            || (m_dwarf_fission && (argumentType == Arg_Rest) && (it->second == Arg_RestAndDwarfFission))) {
                 args.push_back(it->first);
         }
     }
@@ -54,7 +54,17 @@ list<string> CompileJob::remoteFlags() const
 
 std::list<std::string> CompileJob::remoteAndRestFlags() const
 {
-    return flags(Arg_Remote|Arg_Rest);
+    list<string> args;
+
+    for (ArgumentsList::const_iterator it = m_flags.begin(); it != m_flags.end(); ++it) {
+        if (it->second == Arg_Rest
+            || it->second == Arg_Remote
+            || (m_dwarf_fission && (it->second == Arg_RestAndDwarfFission))) {
+                args.push_back(it->first);
+        }
+    }
+
+    return args;
 }
 
 list<string> CompileJob::restFlags() const
@@ -67,7 +77,7 @@ list<string> CompileJob::allFlags() const
     list<string> args;
 
     for (ArgumentsList::const_iterator it = m_flags.begin(); it != m_flags.end(); ++it) {
-        if (m_dwarf_fission || !(it->second & Arg_RestAndDwarfFission)) {
+        if (m_dwarf_fission || it->second != Arg_RestAndDwarfFission) {
             args.push_back(it->first);
         }
     }

--- a/services/job.h
+++ b/services/job.h
@@ -29,9 +29,10 @@
 #include <sstream>
 
 typedef enum {
-    Arg_Local,  // Local-only args.
-    Arg_Remote, // Remote-only args.
-    Arg_Rest    // Args to use both locally and remotely.
+    Arg_Local = 0x1,               // Local-only args.
+    Arg_Remote = 0x2,              // Remote-only args.
+    Arg_RestAndDwarfFission = 0x4, // like Arg_Rest, but only if DwarfFission is enabled.
+    Arg_Rest = 0x8                 // Args to use both locally and remotely.
 } Argument_Type;
 
 class ArgumentsList : public std::list<std::pair<std::string, Argument_Type> >
@@ -121,6 +122,7 @@ public:
     }
     std::list<std::string> localFlags() const;
     std::list<std::string> remoteFlags() const;
+    std::list<std::string> remoteAndRestFlags() const;
     std::list<std::string> restFlags() const;
     std::list<std::string> allFlags() const;
 
@@ -202,7 +204,7 @@ public:
     }
 
 private:
-    std::list<std::string> flags(Argument_Type argumentType) const;
+    std::list<std::string> flags(int argumentType) const;
     void setTargetPlatform();
 
     unsigned int m_id;

--- a/services/job.h
+++ b/services/job.h
@@ -29,10 +29,10 @@
 #include <sstream>
 
 typedef enum {
-    Arg_Local = 0x1,               // Local-only args.
-    Arg_Remote = 0x2,              // Remote-only args.
-    Arg_RestAndDwarfFission = 0x4, // like Arg_Rest, but only if DwarfFission is enabled.
-    Arg_Rest = 0x8                 // Args to use both locally and remotely.
+    Arg_Local,               // Local-only args.
+    Arg_Remote,              // Remote-only args.
+    Arg_RestAndDwarfFission, // like Arg_Rest, but only if DwarfFission is enabled.
+    Arg_Rest                 // Args to use both locally and remotely.
 } Argument_Type;
 
 class ArgumentsList : public std::list<std::pair<std::string, Argument_Type> >
@@ -204,7 +204,7 @@ public:
     }
 
 private:
-    std::list<std::string> flags(int argumentType) const;
+    std::list<std::string> flags(Argument_Type argumentType) const;
     void setTargetPlatform();
 
     unsigned int m_id;

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1208,6 +1208,12 @@ debug_test()
         stop_ice 0
         abort_tests
     fi
+
+    # for binaries without debug infos we suffer from the same gcc-4.8+ behaviour as the readelf check below
+    # so remove symbol and stack addresses and let the readelf check handle that
+    sed -i -e 's/=0x[0-9a-fA-F]*//g' "$testdir"/debug-output-remote.txt
+    sed -i -e 's/=0x[0-9a-fA-F]*//g' "$testdir"/debug-output-local.txt
+
     if ! diff "$testdir"/debug-output-local.txt "$testdir"/debug-output-remote.txt >/dev/null; then
         echo Gdb output different.
         echo =====================

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1769,6 +1769,7 @@ fi
 
 if command -v gdb >/dev/null; then
     if command -v readelf >/dev/null; then
+        debug_test "$TESTCXX" "-c -g0 debug.cpp" "Temporary breakpoint 1, 0x"
         debug_test "$TESTCXX" "-c -g debug.cpp" "Temporary breakpoint 1, main () at debug.cpp:8"
         debug_test "$TESTCXX" "-c -g $(pwd)/debug/debug2.cpp" "Temporary breakpoint 1, main () at $(pwd)/debug/debug2.cpp:8"
         if test -z "$debug_fission_disabled"; then

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1773,6 +1773,7 @@ if command -v gdb >/dev/null; then
         debug_test "$TESTCXX" "-c -g $(pwd)/debug/debug2.cpp" "Temporary breakpoint 1, main () at $(pwd)/debug/debug2.cpp:8"
         if test -z "$debug_fission_disabled"; then
             debug_test "$TESTCXX" "-c -g debug.cpp -gsplit-dwarf" "Temporary breakpoint 1, main () at debug.cpp:8"
+            debug_test "$TESTCXX" "-c debug.cpp -gsplit-dwarf -g0" "Temporary breakpoint 1, 0x"
             debug_test "$TESTCXX" "-c -g $(pwd)/debug/debug2.cpp -gsplit-dwarf" "Temporary breakpoint 1, main () at $(pwd)/debug/debug2.cpp:8"
         fi
     fi


### PR DESCRIPTION
Fixing issue #424 . Especially to fix reordering of -g<level> and -gsplit-dwarf compiler arguments. 