### PR TITLE
limit the ICECC_REMOTE_CPP/-pedantic workaround to avoid new breakage

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -258,6 +258,7 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
     bool wunused_macros = false;
     bool seen_arch = false;
     bool seen_pedantic = false;
+    const char *standard = NULL;
     // if rewriting includes and precompiling on remote machine, then cpp args are not local
     Argument_Type Arg_Cpp = compiler_only_rewrite_includes(job) ? Arg_Rest : Arg_Local;
 
@@ -856,8 +857,10 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
         job.setBlockRewriteIncludes(true);
     }
 
-    // -pedantic doeesn't work with remote preprocessing
-    if( seen_pedantic ) {
+    // -pedantic doesn't work with remote preprocessing, if extensions to a named standard
+    // are allowed.  GCC allows GNU extensions by default, so let's check if a standard
+    // other than eg gnu11 or gnu++14 was specified.
+    if( seen_pedantic && (!standard || str_startswith("gnu", standard)) ) {
         job.setBlockRewriteIncludes(true);
     }
 


### PR DESCRIPTION
ICECC_REMOTE_CPP is typically used to avoid remote (clang) compilation
errors, so we should avoid disabling it where possible.

The test case in #410 passes if you specify an official language
standard rather than using GCC's default (which allows GNU extensions).
Let's check this before deciding to disable ICECC_REMOTE_CPP.

Followup to #411.