### PR TITLE
Additional Assembler Files for Linux Kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ tests/testargs
 tests/testargs.log
 tests/testargs.trs
 tests/test-setup.sh
+tests/listing.txt

--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -260,6 +260,12 @@ static bool analyze_assembler_arg(string &arg)
                str_equal("--defsym", pos)) {
         second_option = true;
         return false;
+    } else if (pos[0] == '@') {
+        /* If a build system passes an @FILE argument we'd need to
+         * parse the file for more arguments. Instead, we'll just
+         * run locally.
+         */
+        return true;
     } else {
         /* Some weird build systems pass directly additional assembler files.
          * Example: -Wa,src/code16gcc.s

--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -234,6 +234,12 @@ static bool is_argument_with_space(const char* argument)
 static bool analyze_assembler_arg(string &arg)
 {
     const char *pos = arg.c_str();
+    static bool second_option;
+
+    if (second_option) {
+        second_option = false;
+        return false;
+    }
 
     if (str_startswith("-a", pos)) {
         /* -a[a-z]*=output, which directs the listing to the named file
@@ -249,6 +255,10 @@ static bool analyze_assembler_arg(string &arg)
             return true;
         }
 
+        return false;
+    } else if (str_equal("--debug-prefix-map", pos) ||
+               str_equal("--defsym", pos)) {
+        second_option = true;
         return false;
     } else {
         /* Some weird build systems pass directly additional assembler files.

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -229,7 +229,6 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
         argc++; // the program
         argc += 6; // -x c - -o file.o -fpreprocessed
         argc += 4; // gpc parameters
-        argc += 1; // -pipe
         argc += 9; // clang extra flags
         char **argv = new char*[argc + 1];
         int i = 0;
@@ -285,23 +284,13 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
             error_client(client, "/tmp dir missing?");
         }
 
-        bool hasPipe = false;
-
         for (std::list<string>::const_iterator it = list.begin();
                 it != list.end(); ++it) {
-            if (*it == "-pipe") {
-                hasPipe = true;
-            }
-
             argv[i++] = strdup(it->c_str());
         }
 
         if (!clang) {
             argv[i++] = strdup("-fpreprocessed");
-        }
-
-        if (!hasPipe) {
-            argv[i++] = strdup("-pipe");
         }
 
         argv[i++] = strdup("-");

--- a/tests/assembler.args
+++ b/tests/assembler.args
@@ -1,0 +1,1 @@
+-al=listing.txt

--- a/tests/macros.s
+++ b/tests/macros.s
@@ -1,0 +1,4 @@
+
+
+.macro asm_macro
+.endm

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1674,7 +1674,7 @@ run_ice "$testdir/includes.o" "remote" 0 $TESTCXX -Wall -Werror -c includes-with
 run_ice "$testdir/plain.o" "local" 0 $TESTCXX -Wall -Werror -c plain.cpp -mtune=native -o "$testdir"/plain.o
 run_ice "$testdir/plain.o" "remote" 0 $TESTCC -Wall -Werror -x c++ -c plain -o "$testdir"/plain.o
 run_ice "$testdir/plain.o" "local" 0 $TESTCC -Wa,-al=listing.txt -Wall -Werror -c plain.c -o "$testdir/"plain.o
-run_ice "$testdir/plain.o" "local" 0 $TESTCC -Wa,macros.s -Wall -Werror -c plain.c -o "$testdir/"plain.o
+run_ice "$testdir/plain.o" "remote" 0 $TESTCC -Wa,macros.s -Wall -Werror -c plain.c -o "$testdir/"plain.o
 run_ice "$testdir/plain.o" "remote" 0 $TESTCC -Wa,--defsym,MYSYM=yes -Wall -Werror -c plain.c -o "$testdir/"plain.o
 run_ice "$testdir/plain.o" "local" 0 $TESTCC -Wa,@assembler.args -Wall -Werror -c plain.c -o "$testdir/"plain.o
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1676,6 +1676,7 @@ run_ice "$testdir/plain.o" "remote" 0 $TESTCC -Wall -Werror -x c++ -c plain -o "
 run_ice "$testdir/plain.o" "local" 0 $TESTCC -Wa,-al=listing.txt -Wall -Werror -c plain.c -o "$testdir/"plain.o
 run_ice "$testdir/plain.o" "local" 0 $TESTCC -Wa,macros.s -Wall -Werror -c plain.c -o "$testdir/"plain.o
 run_ice "$testdir/plain.o" "remote" 0 $TESTCC -Wa,--defsym,MYSYM=yes -Wall -Werror -c plain.c -o "$testdir/"plain.o
+run_ice "$testdir/plain.o" "local" 0 $TESTCC -Wa,@assembler.args -Wall -Werror -c plain.c -o "$testdir/"plain.o
 
 run_ice "$testdir/testdefine.o" "remote" 0 $TESTCXX -Wall -Werror -DICECREAM_TEST_DEFINE=test -c testdefine.cpp -o "$testdir/"testdefine.o
 run_ice "$testdir/testdefine.o" "remote" 0 $TESTCXX -Wall -Werror -D ICECREAM_TEST_DEFINE=test -c testdefine.cpp -o "$testdir/"testdefine.o

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1675,6 +1675,7 @@ run_ice "$testdir/plain.o" "local" 0 $TESTCXX -Wall -Werror -c plain.cpp -mtune=
 run_ice "$testdir/plain.o" "remote" 0 $TESTCC -Wall -Werror -x c++ -c plain -o "$testdir"/plain.o
 run_ice "$testdir/plain.o" "local" 0 $TESTCC -Wa,-al=listing.txt -Wall -Werror -c plain.c -o "$testdir/"plain.o
 run_ice "$testdir/plain.o" "local" 0 $TESTCC -Wa,macros.s -Wall -Werror -c plain.c -o "$testdir/"plain.o
+run_ice "$testdir/plain.o" "remote" 0 $TESTCC -Wa,--defsym,MYSYM=yes -Wall -Werror -c plain.c -o "$testdir/"plain.o
 
 run_ice "$testdir/testdefine.o" "remote" 0 $TESTCXX -Wall -Werror -DICECREAM_TEST_DEFINE=test -c testdefine.cpp -o "$testdir/"testdefine.o
 run_ice "$testdir/testdefine.o" "remote" 0 $TESTCXX -Wall -Werror -D ICECREAM_TEST_DEFINE=test -c testdefine.cpp -o "$testdir/"testdefine.o

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1673,6 +1673,8 @@ run_ice "$testdir/includes.o" "remote" 0 $TESTCXX -Wall -Werror -c includes.cpp 
 run_ice "$testdir/includes.o" "remote" 0 $TESTCXX -Wall -Werror -c includes-without.cpp -include includes.h -o "$testdir"/includes.o
 run_ice "$testdir/plain.o" "local" 0 $TESTCXX -Wall -Werror -c plain.cpp -mtune=native -o "$testdir"/plain.o
 run_ice "$testdir/plain.o" "remote" 0 $TESTCC -Wall -Werror -x c++ -c plain -o "$testdir"/plain.o
+run_ice "$testdir/plain.o" "local" 0 $TESTCC -Wa,-al=listing.txt -Wall -Werror -c plain.c -o "$testdir/"plain.o
+run_ice "$testdir/plain.o" "local" 0 $TESTCC -Wa,macros.s -Wall -Werror -c plain.c -o "$testdir/"plain.o
 
 run_ice "$testdir/testdefine.o" "remote" 0 $TESTCXX -Wall -Werror -DICECREAM_TEST_DEFINE=test -c testdefine.cpp -o "$testdir/"testdefine.o
 run_ice "$testdir/testdefine.o" "remote" 0 $TESTCXX -Wall -Werror -D ICECREAM_TEST_DEFINE=test -c testdefine.cpp -o "$testdir/"testdefine.o


### PR DESCRIPTION
This pull request addresses issue #428.

The patchset adds some unit tests and improves the way assembler arguments are parsed (those that begin with -Wa). Any files specified with -Wa are added to the extra files included in the environment.

It was also necessary to remove the forced -pipe option as this is incompatible with extra assembly files (with GCC) and the benefits of this are dubious at best.

With the patchset, compiling the latest version of the Linux kernel will properly distribute all compile steps.