### PR TITLE
Various fixes related to Clear Linux

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -452,7 +452,7 @@ fi
 
 # special case for weird multilib setups
 for dir in /lib /lib64 /usr/lib /usr/lib64; do
-    test -L $dir && cp -p $dir $tempdir$dir
+    test -L $dir && cp -Pp $dir $tempdir$dir
 done
 
 new_target_files=

--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -109,6 +109,7 @@ add_file ()
 		#         libc.so.6 => /lib/tls/libc.so.6 (0xb7e81000)
 		#         /lib/ld-linux.so.2 (0xb7fe8000)
 		# covering both situations ( with => and without )
+           local lib
            for lib in $(ldd "$path" | sed -n 's,^[^/]*\(/[^ ]*\).*,\1,p'); do
 	      test -f "$lib" || continue
 	      # Check wether the same library also exists in the parent directory,
@@ -116,6 +117,23 @@ add_file ()
 	      local baselib=$(echo "$lib" | sed 's,\(/[^/]*\)/.*\(/[^/]*\)$,\1\2,')
 	      test -f "$baselib" && lib=$baselib
               add_file "$lib"
+
+              # Add the non-haswell and non-avx512_1 libraries too
+              case "$lib" in
+                 */haswell/*|*/avx512_1/*)
+                    ;;
+                 *)
+                    continue
+                    ;;
+              esac
+              local lib_non_avx512=$(echo "$lib" | sed s,/avx512_1/,/,)
+              local lib_non_hsw=$(echo "$lib_non_avx512" | sed s,/haswell/,/,)
+              if [ "$lib" != "$lib_non_avx512" ] && [ -f "$lib_non_avx512" ]; then
+                add_file "$lib_non_avx512"
+              fi
+              if [ "$lib" != "$lib_non_hsw" ] && [ -f "$lib_non_hsw" ]; then
+                add_file "$lib_non_hsw"
+              fi
            done
         fi
     elif test "$is_darwin" = 1; then

--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -476,7 +476,11 @@ done
 if test -x /sbin/ldconfig -a "$is_linux" = 1; then
    mkdir -p $tempdir/var/cache/ldconfig
    /sbin/ldconfig -r $tempdir
-   new_target_files="$new_target_files etc/ld.so.cache"
+   for candidate in etc var/cache/ldconfig; do
+        test -e $tempdir/$candidate/ld.so.cache || continue;
+        new_target_files="$new_target_files $candidate/ld.so.cache"
+        break
+   done
 fi
 
 md5sum=NONE


### PR DESCRIPTION
In Clear, /lib64 is a symlink to /usr/lib64, ld.so.cache is not in /etc and we do have AVX2 and AVX512 optimised libraries (notably, libm.so.6)