### PR TITLE
Add support for Zstandard compression of the content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
   - os: osx
     before_install:
       - brew update
-      - brew install lzo docbook2x gdb ccache
+      - brew install lzo zstd docbook2x gdb ccache
   - os: linux
     sudo: true # for setcap so we can run the tests in chroot.
     compiler: clang
@@ -99,6 +99,7 @@ addons:
     - libcap-ng-dev
     - libcap-ng-utils
     - liblzo2-dev
+    - libzstd1-dev
     - docbook2x
     - realpath
     - gdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ matrix:
   - os: linux
     sudo: true # for setcap so we can run the tests in chroot.
     compiler: gcc
-    dist: trusty
+    dist: xenial
   - os: linux
     sudo: true # for setcap so we can run the tests in chroot.
     compiler: clang
-    dist: trusty
+    dist: xenial
   - os: osx
     before_install:
       - brew update
@@ -46,25 +46,25 @@ matrix:
     sudo: true # for setcap so we can run the tests in chroot.
     compiler: clang
     env: VALGRIND=1
-    dist: trusty
-  - os: linux
-    sudo: true # for setcap so we can run the tests in chroot.
-    compiler: clang
-    env: BUILD_TYPE=asan
-    dist: trusty
-    # Sanitizer builds with newer travis fail for unknown reason without giving any message.
-    group: deprecated-2017Q4
-  - os: linux
-    sudo: true # for setcap so we can run the tests in chroot.
-    compiler: clang
-    env: BUILD_TYPE=lsan
-    dist: trusty
-    group: deprecated-2017Q4
+    dist: xenial
+# - os: linux
+#   sudo: true # for setcap so we can run the tests in chroot.
+#   compiler: clang
+#   env: BUILD_TYPE=asan
+#   dist: xenial
+#   # Sanitizer builds with newer travis fail for unknown reason without giving y message.
+#   group: deprecated-2017Q4
+# - os: linux
+#   sudo: true # for setcap so we can run the tests in chroot.
+#   compiler: clang
+#   env: BUILD_TYPE=lsan
+#   dist: xenial
+#   group: deprecated-2017Q4
   - os: linux
     sudo: true # for setcap so we can run the tests in chroot.
     compiler: clang
     env: BUILD_TYPE=ubsan
-    dist: trusty
+    dist: xenial
   allow_failures:
 
 before_script:

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -97,6 +97,7 @@ static void dcc_show_usage(void)
         "   ICECC_EXTRAFILES           additional files used in the compilation.\n"
         "   ICECC_COLOR_DIAGNOSTICS    set to 1 or 0 to override color diagnostics support.\n"
         "   ICECC_CARET_WORKAROUND     set to 1 or 0 to override gcc show caret workaround.\n"
+        "   ICECC_COMPRESSION          if set, the libzstd compression level (1 to 19, default: 1)"
         "\n");
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -188,6 +188,10 @@ AC_CHECK_LIB(lzo2, lzo1x_1_compress, LZO_LDADD=-llzo2,
 	AC_MSG_ERROR([Could not find lzo2 library - please install lzo-devel]))
 AC_SUBST(LZO_LDADD)
 
+AC_CHECK_LIB(zstd, ZSTD_compress, ZSTD_LDADD=-lzstd,
+        AC_MSG_ERROR([Could not find zstd library - please install libzstd-devel]))
+AC_SUBST(ZSTD_LDADD)
+
 AC_CHECK_LIB([dl], [dlsym], [DL_LDADD=-ldl])
 AC_SUBST([DL_LDADD])
 

--- a/services/Makefile.am
+++ b/services/Makefile.am
@@ -2,6 +2,7 @@ lib_LTLIBRARIES = libicecc.la
 libicecc_la_SOURCES = job.cpp comm.cpp exitcode.cpp getifaddrs.cpp logging.cpp tempfile.c platform.cpp gcc.cpp
 libicecc_la_LIBADD = \
 	$(LZO_LDADD) \
+	$(ZSTD_LDADD) \
 	$(CAPNG_LDADD) \
 	$(DL_LDADD)
 

--- a/services/comm.h
+++ b/services/comm.h
@@ -36,7 +36,7 @@
 #include "job.h"
 
 // if you increase the PROTOCOL_VERSION, add a macro below and use that
-#define PROTOCOL_VERSION 39
+#define PROTOCOL_VERSION 40
 // if you increase the MIN_PROTOCOL_VERSION, comment out macros below and clean up the code
 #define MIN_PROTOCOL_VERSION 21
 
@@ -64,6 +64,7 @@
 #define IS_PROTOCOL_37(c) ((c)->protocol >= 37)
 #define IS_PROTOCOL_38(c) ((c)->protocol >= 38)
 #define IS_PROTOCOL_39(c) ((c)->protocol >= 39)
+#define IS_PROTOCOL_40(c) ((c)->protocol >= 40)
 
 // Terms used:
 // S  = scheduler
@@ -138,6 +139,11 @@ enum MsgType {
     M_BLACKLIST_HOST_ENV,
     // S --> CS
     M_NO_CS
+};
+
+enum Compression {
+    C_LZO = 0,
+    C_ZSTD = 1
 };
 
 class MsgChannel;


### PR DESCRIPTION
Zstandard (https://zstd.net) is a modern compression library also of the
Lempel-Ziv family of compressors. Compared to LZO, if given the same CPU
time, zstd will compress better. Testing with the "lzop" and "zstd"
command-line tools indicates that the same-CPU-time level compression
for a 7241 kB preprocessed source lies between zstd levels 2 and 3 (LZO
takes 916 µs; zstd level 2 takes 753 µs and level 3 takes 1024 µs).
Level 2 compresses this file to 1028 kB, while level 3 reaches 929 kB,
compared to LZO's 1581 kB.

However, when testing a full compilation of a large-ish source code (not
including linking), we find that CPU time is the bottleneck, shared
between the compressor and the preprocessors. The results of a best-of-5
run on this source are:

	lzo:    22.989s
	zstd1:  20.421s
	zstd2:  20.554s
	zstd3:  20.630s
	zstd4:  20.762s
	zstd5:  21.355s
	zstd6:  21.341s

Therefore, this commit chooses level 1 as the default. The 11% gain in
build time is caused the reduction in both CPU contention and the
network transmission -- zstd level 1 compresses the above source to 1029
kB, which is almost 35% smaller than the LZO content.