### PR TITLE
Improve ccache + icecc advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ in your path, as CCACHE_PREFIX is instructing ccache to explicitly delegate
 to icecc rather than finding it in the path. If both ccache and icecc's
 symlinks are in the path it is likely the two wrappers will mistake each
 other for the real compiler and icecc will complain that it has recursively
-invokes itself.
+invoked itself.
 
 Note however that ccache isn't really worth the trouble if you're not
 recompiling your project three times a day from scratch (it adds some

--- a/README.md
+++ b/README.md
@@ -383,6 +383,13 @@ And then compile with
 
      export PATH=/opt/ccache/bin:$PATH
 
+In this case icecc's symlinks in /usr/lib/icecc/bin should **not** be 
+in your path, as CCACHE_PREFIX is instructing ccache to explicitly delegate 
+to icecc rather than finding it in the path. If both ccache and icecc's
+symlinks are in the path it is likely the two wrappers will mistake each
+other for the real compiler and icecc will complain that it has recursively
+invokes itself.
+
 Note however that ccache isn't really worth the trouble if you're not
 recompiling your project three times a day from scratch (it adds some
 overhead in comparing the source files and uses quite some disk space).


### PR DESCRIPTION
Clarify that the usual usage pattern for icecc (adding its symlinks to $PATH) should not be followed when using ccache's own symlinks.