### PR TITLE
use tar from PATH instead of configure time absolute path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,9 +109,6 @@ AC_CHECK_HEADERS([resolv.h], [], [],
 #endif
 ])
 
-AC_ARG_VAR(TAR, [Specifies tar path])
-AC_PATH_PROG(TAR, [tar])
-AC_DEFINE_UNQUOTED([TAR], ["$TAR"], [Define path to tar])
 AC_CHECK_HEADERS([netinet/tcp_var.h], [], [],
 [#include <sys/types.h>
 #if HAVE_SYS_SOCKETVAR_H

--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -558,13 +558,13 @@ pid_t start_install_environment(const std::string &basename, const std::string &
 
     char **argv;
     argv = new char*[5];
-    argv[0] = strdup(TAR);
+    argv[0] = strdup("tar");
     argv[1] = strdup("-xC");
     argv[2] = strdup(dirname.c_str());
     argv[3] = decompressor ? strdup(decompressor) : 0;
     argv[4] = 0;
 
-    execv(argv[0], argv);
+    execvp(argv[0], argv);
     log_perror("execv failed");
     _exit(100);
 }


### PR DESCRIPTION
This makes the tar invocation robust against changed tar paths between build and execution host.