### PR TITLE
Keep -Werror=missing-include-dirs local

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -613,7 +613,8 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                        || str_equal("-MG", a)
                        || str_equal("-MP", a)) {
                 args.append(a, Arg_Local);
-            } else if (str_equal("-Wmissing-include-dirs", a)) {
+            } else if (str_equal("-Wmissing-include-dirs", a)
+                       || str_equal("-Werror=missing-include-dirs", a)) {
                 args.append(a, Arg_Local);
             } else if (str_equal("-fno-color-diagnostics", a)) {
                 explicit_color_diagnostics = true;


### PR DESCRIPTION
Looks like #180 was fixed only partially.