### PR TITLE
Removed dependency on native tar command and used libarchive library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,3 +103,4 @@ addons:
     - realpath
     - gdb
     - valgrind
+    - libarchive-dev

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+1.2.1
+- require libarchive
+
 1.2
  - Add more compiler flags to the list that mean build locally
    * -pedantic (preprocessing only)
@@ -14,7 +17,6 @@
  - Cygwin now works as a client
  - Don't expose Host endianness to network
  - General code cleanup
- - require libarchive
  
 1.1
  - revert "Add load control for preprocessing"

--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@
  - Cygwin now works as a client
  - Don't expose Host endianness to network
  - General code cleanup
+ - require libarchive
  
 1.1
  - revert "Add load control for preprocessing"

--- a/README
+++ b/README
@@ -3,6 +3,12 @@ it depends critically on Linux' /proc/ structures and will fail
 at runtime until somebody figures out how to emulate the "ticks"
 form of process accounting in there.
 
+Required Libraries
+==================
+Note: The package name may vary by distro
+* libcap-ng-devel
+* libarchive-devel
+
 How to install icecream
 =======================
 

--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,7 @@ AC_CHECK_HEADERS([netinet/tcp_var.h], [], [],
 ])
 
 AC_CHECK_HEADERS([sys/user.h])
+AC_CHECK_HEADERS([archive.h, archive_entry.h])
 
 ######################################################################
 dnl Checks for types
@@ -190,6 +191,10 @@ AC_SUBST(LZO_LDADD)
 
 AC_CHECK_LIB([dl], [dlsym], [DL_LDADD=-ldl])
 AC_SUBST([DL_LDADD])
+
+AC_CHECK_LIB(archive, archive_read_data_block, ARCHIVE_LDADD=-larchive,
+    AC_MSG_ERROR([Could not find libarchive library - please install libarchive-devel]))
+AC_SUBST(ARCHIVE_LDADD)
 
 # In DragonFlyBSD daemon needs to be linked against libkinfo.
 case $host_os in

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -12,7 +12,8 @@ iceccd_SOURCES = \
 iceccd_LDADD = \
 	../services/libicecc.la \
 	$(LIB_KINFO) \
-	$(CAPNG_LDADD)
+	$(CAPNG_LDADD) \
+	$(ARCHIVE_LDADD)
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/services

--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -112,7 +112,7 @@ static bool exec_and_wait(const char *const argv[])
         // parent
         int status;
 
-        while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
+        while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
 
         return shell_exit_status(status) == 0;
     }
@@ -401,7 +401,7 @@ size_t finish_create_env(int pipe, const string &basedir, string &native_environ
     char buf[1024];
     buf[0] = '\0';
 
-    while (read(pipe, buf, 1023) < 0 && errno == EINTR);
+    while (read(pipe, buf, 1023) < 0 && errno == EINTR) {}
 
     if (char *nl = strchr(buf, '\n')) {
         *nl = '\0';
@@ -458,7 +458,7 @@ pid_t start_install_environment(const std::string &basename, const std::string &
                                 int &pipe_to_stdin, FileChunkMsg *&fmsg,
                                 uid_t user_uid, gid_t user_gid, int extract_priority)
 {
-    log_error() << "start_install_environment: " << basename << " target "<<target << " Name: " << name << endl;
+    log_info() << "start_install_environment: " << basename << " target "<<target << " Name: " << name << endl;
     if (!name.size()) {
         log_error() << "illegal name for environment " << name << endl;
         return 0;
@@ -593,7 +593,7 @@ pid_t start_install_environment(const std::string &basename, const std::string &
     archive_write_disk_set_standard_lookup(ext);
 
     if(archive_read_open_fd(a, 0, fmsg->len)){
-        trace() << "start_install_environment: "<< "archive_read_open_fd faied"<< endl;
+        log_error() << "start_install_environment: "<< "archive_read_open_fd faied"<< endl;
         _exit(1);
     }
 
@@ -604,7 +604,7 @@ pid_t start_install_environment(const std::string &basename, const std::string &
             break;
         }
         if (r < ARCHIVE_WARN){
-            trace() << "start_install_environment: r  < ARCHIVE_WARN " <<archive_error_string(a)<<endl;   
+            log_error() << "start_install_environment: r  < ARCHIVE_WARN " <<archive_error_string(a)<<endl;   
             _exit(1);
         }
 
@@ -617,12 +617,13 @@ pid_t start_install_environment(const std::string &basename, const std::string &
         if(archive_entry_size(entry) > 0){
             r= copy_data(a, ext);
             if(r < ARCHIVE_WARN){
-                trace()<< "start_install_environment: " << archive_error_string(ext)<<endl;
+                log_error()<< "start_install_environment: " << archive_error_string(ext)<<endl;
                 _exit(1);
             }
         }
         r=archive_write_finish_entry(ext);
         if(r<ARCHIVE_WARN){
+            log_error() << "start_install_environment: " << archive_error_string(ext)<<endl;
             _exit(1);
         }
     }
@@ -645,7 +646,7 @@ size_t finalize_install_environment(const std::string &basename, const std::stri
         return 0;
     }
     trace() << "finalize_install_environment started for " << basename << " target " << target << " arriving on PID " << pid <<endl;
-    while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
 
     string dirname = basename + "/target=" + target;
 
@@ -678,7 +679,7 @@ size_t remove_environment(const string &basename, const string &env)
     if (pid) {
         int status = 0;
 
-        while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
+        while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
 
         if (WIFEXITED(status)) {
             return res;
@@ -814,7 +815,7 @@ bool verify_env(MsgChannel *client, const string &basedir, const string &target,
     if (pid > 0) {  // parent
         int status;
 
-        while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
+        while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
 
         return shell_exit_status(status) == 0;
     } else if (pid < 0) {

--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -38,6 +38,9 @@
 #include "exitcode.h"
 #include "util.h"
 
+#include <archive.h>
+#include <archive_entry.h>
+
 using namespace std;
 
 size_t sumup_dir(const string &dir)
@@ -109,7 +112,7 @@ static bool exec_and_wait(const char *const argv[])
         // parent
         int status;
 
-        while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
+        while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
 
         return shell_exit_status(status) == 0;
     }
@@ -398,7 +401,7 @@ size_t finish_create_env(int pipe, const string &basedir, string &native_environ
     char buf[1024];
     buf[0] = '\0';
 
-    while (read(pipe, buf, 1023) < 0 && errno == EINTR) {}
+    while (read(pipe, buf, 1023) < 0 && errno == EINTR);
 
     if (char *nl = strchr(buf, '\n')) {
         *nl = '\0';
@@ -425,11 +428,37 @@ size_t finish_create_env(int pipe, const string &basedir, string &native_environ
 }
 
 
+
+static int copy_data(struct archive *ar, struct archive *aw)
+{
+    int r;
+    const void *buff;
+    size_t size;
+
+#if ARCHIVE_VERSION_NUMBER >= 3000000
+    int64_t offset;
+#else
+    off_t offset;
+#endif
+    for(;;){
+        r = archive_read_data_block(ar, &buff, &size, &offset);
+        if (r == ARCHIVE_EOF){
+            return (ARCHIVE_OK);
+        }
+        r= archive_write_data_block(aw, buff, size, offset);
+        if(r != ARCHIVE_OK){
+            trace() << "COPY_DATA: Error after write"<< archive_error_string(aw)<<endl;
+            return (r);
+        }
+    }
+}
+
 pid_t start_install_environment(const std::string &basename, const std::string &target,
                                 const std::string &name, MsgChannel *c,
                                 int &pipe_to_stdin, FileChunkMsg *&fmsg,
                                 uid_t user_uid, gid_t user_gid, int extract_priority)
 {
+    log_error() << "start_install_environment: " << basename << " target "<<target << " Name: " << name << endl;
     if (!name.size()) {
         log_error() << "illegal name for environment " << name << endl;
         return 0;
@@ -453,19 +482,6 @@ pid_t start_install_environment(const std::string &basename, const std::string &
     }
 
     fmsg = dynamic_cast<FileChunkMsg*>(msg);
-    const char *decompressor = NULL;
-
-    if (fmsg->len > 2) {
-        if (fmsg->buffer[0] == 037 && fmsg->buffer[1] == 0213) {
-            decompressor = "-z";    // --gzip
-        } else if (fmsg->buffer[0] == 'B' && fmsg->buffer[1] == 'Z') {
-            decompressor = "-j";    // --bzip2
-        } else if (fmsg->buffer[0] == 0xfd && fmsg->buffer[1] == 0x37) {
-            decompressor = "-J";    // --xz
-        } else if (fmsg->buffer[0] == 0x28 && fmsg->buffer[1] == 0xb5) {
-            decompressor = "-Iunzstd";
-        }
-    }
 
     if (mkdir(dirname.c_str(), 0770) && errno != EEXIST) {
         log_perror("mkdir target") << "\t" << dirname << endl;
@@ -489,10 +505,10 @@ pid_t start_install_environment(const std::string &basename, const std::string &
         return 0;
     }
 
-    int fds[2];
+    int fds[2]; //File descriptor for Pipe
 
     if (pipe(fds) == -1) {
-        log_perror("pipe failed");
+        log_perror("start_install_environment: pipe creation failed for recveiving environment");
         return 0;
     }
 
@@ -500,16 +516,17 @@ pid_t start_install_environment(const std::string &basename, const std::string &
     pid_t pid = fork();
 
     if (pid == -1) {
-        log_perror("fork - trying to run tar");
+        log_perror("Failed to fork - trying to run tar");
         return 0;
     }
     if (pid) {
-        trace() << "pid " << pid << endl;
+        //Runs only on parent(PID value is 0 in child and PID id on parent)
+        trace() << "Created fork for recveiving environment on pid " << pid << endl;
 
         if ((-1 == close(fds[0])) && (errno != EBADF)){
-            log_perror("close failed");
+            log_perror("Failed to close read end of pipe");
         }
-        pipe_to_stdin = fds[1];
+        pipe_to_stdin = fds[1]; //Set write end of pipe to pass to parent thread
 
         return pid;
     }
@@ -540,15 +557,16 @@ pid_t start_install_environment(const std::string &basename, const std::string &
     signal(SIGPIPE, SIG_DFL);
 
     if ((-1 == close(0)) && (errno != EBADF)){
-        log_perror("close failed");
+        //https://linux.die.net/man/3/close
+        log_perror("Failed to close standard input");
     }
 
     if ((-1 == close(fds[1])) && (errno != EBADF)){
-        log_perror("close failed");
+        log_perror("Failed to close write end of pipe");
     }
 
     if (-1 == dup2(fds[0], 0)){
-        log_perror("dup2 failed");
+        log_perror("Failed to duplicate file descriptor for read end of pipe with standard input");
     }
 
     int niceval = nice(extract_priority);
@@ -556,16 +574,65 @@ pid_t start_install_environment(const std::string &basename, const std::string &
         log_warning() << "failed to set nice value: " << strerror(errno) << endl;
     }
 
-    char **argv;
-    argv = new char*[5];
-    argv[0] = strdup(TAR);
-    argv[1] = strdup("-xC");
-    argv[2] = strdup(dirname.c_str());
-    argv[3] = decompressor ? strdup(decompressor) : 0;
-    argv[4] = 0;
+    /* libarchive stream reader */
+    struct archive *a;
+    struct archive *ext;
+    struct archive_entry *entry;
+    int flags;
+    int r;
 
-    execv(argv[0], argv);
-    log_perror("execv failed");
+    flags = ARCHIVE_EXTRACT_TIME;
+    flags |= ARCHIVE_EXTRACT_PERM;
+    flags |= ARCHIVE_EXTRACT_ACL;
+    flags |= ARCHIVE_EXTRACT_FFLAGS;
+
+    a=archive_read_new();
+    archive_read_support_format_all(a);
+    archive_read_support_filter_all(a);
+    ext = archive_write_disk_new();
+    archive_write_disk_set_options(ext, flags);
+    archive_write_disk_set_standard_lookup(ext);
+
+    if((r=archive_read_open_fd(a, 0, fmsg->len))){
+        trace() << "start_install_environment: "<< "archive_read_open_fd faied"<< endl;
+        _exit(1);
+    }
+
+    for(;;){
+        r = archive_read_next_header(a, &entry);
+        if (r == ARCHIVE_EOF) {
+            trace() << "start_install_environment: reached end of archive while recveiving environment "<< endl;
+            break;
+        }
+        if (r < ARCHIVE_WARN){
+            trace() << "start_install_environment: r  < ARCHIVE_WARN " <<archive_error_string(a)<<endl;   
+            _exit(1);
+        }
+
+        /*Extracting archive*/
+        const char* currentFile = archive_entry_pathname(entry);
+        const std::string fullOutputPath = dirname + "/"+currentFile;
+        archive_entry_set_pathname(entry, fullOutputPath.c_str());
+        r = archive_write_header(ext, entry);
+
+        if(archive_entry_size(entry) > 0){
+            r= copy_data(a, ext);
+            if(r < ARCHIVE_WARN){
+                trace()<< "start_install_environment: " << archive_error_string(ext)<<endl;
+                _exit(1);
+            }
+        }
+        r=archive_write_finish_entry(ext);
+        if(r<ARCHIVE_WARN){
+            _exit(1);
+        }
+    }
+    archive_read_close(a);
+    archive_read_free(a);
+    archive_write_close(ext);
+    archive_write_free(ext);
+    /*libarchive stream reader ends*/
+
     _exit(100);
 }
 
@@ -574,14 +641,12 @@ size_t finalize_install_environment(const std::string &basename, const std::stri
                                     pid_t pid, uid_t user_uid, gid_t user_gid)
 {
     int status = 1;
-
-    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
-
-    if (shell_exit_status(status) != 0) {
-        log_error() << "exit code: " << shell_exit_status(status) << endl;
-        remove_environment(basename, target);
+    if (pid < 1){
+        log_error() << "finalize_install_environment: Invalid pid " << pid << endl;
         return 0;
     }
+    trace() << "finalize_install_environment started for " << basename << " target " << target << " arriving on PID " << pid <<endl;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
 
     string dirname = basename + "/target=" + target;
 
@@ -614,7 +679,7 @@ size_t remove_environment(const string &basename, const string &env)
     if (pid) {
         int status = 0;
 
-        while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
+        while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
 
         if (WIFEXITED(status)) {
             return res;
@@ -750,11 +815,11 @@ bool verify_env(MsgChannel *client, const string &basedir, const string &target,
     if (pid > 0) {  // parent
         int status;
 
-        while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
+        while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
 
         return shell_exit_status(status) == 0;
     } else if (pid < 0) {
-        log_perror("fork failed");
+        log_perror("Failed to fork for verifying environment");
         return false;
     }
 


### PR DESCRIPTION
Replaced call to tar utility and added support for libarchive library instead as we were having issues with tar hanging up infinitely for EOF forcing us to restart iceccd. This gives the ability to use all environments supported by libarchive without having to depend on an external utility.

Also added more descriptive log messages.