### PR TITLE
force local rebuild if remote is missing file

### DIFF
--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -586,6 +586,12 @@ static int build_remote_int(CompileJob &job, UseCSMsg *usecs, MsgChannel *local_
                 throw remote_error(102, "Error 102 - command needs stdout/stderr workaround, recompiling locally");
             }
 
+            if (crmsg->err.find("file not found") != string::npos) {
+                delete crmsg;
+                log_info() << "remote is missing file, recompiling locally" << endl;
+                throw remote_error(103, "Error 104 - remote is missing file, recompiling locally");
+            }
+
             ignore_result(write(STDOUT_FILENO, crmsg->out.c_str(), crmsg->out.size()));
 
             if (colorify_wanted(job)) {


### PR DESCRIPTION
There are cases where a remote compilation is failing due to a missing
file, that we can't detect with limited amount of work before kicking
off the compile. One such occasion is the Linux kernel including a file
in a inline ASM statement in a C file via the incbin directive.

If we detect a remote error with a missing file, force a local recompile.
This should only be hit in a very limited number of cases, so there is no
need for a more clever workaround.