### PR TITLE
handle -MF, -MT and -MQ when passed via -Wp

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -370,12 +370,14 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                 args.append(a, Arg_Local);
                 /* These just modify the behaviour of other -M* options and do
                  * nothing by themselves. */
-            } else if (!strcmp(a, "-MF")) {
+            } else if (!strcmp(a, "-MF") || str_startswith("-Wp,-MF", a)) {
                 seen_mf = true;
                 args.append(a, Arg_Local);
                 args.append(argv[++i], Arg_Local);
                 /* as above but with extra argument */
-            } else if (!strcmp(a, "-MT") || !strcmp(a, "-MQ")) {
+            } else if (!strcmp(a, "-MT") || !strcmp(a, "-MQ") ||
+                       str_startswith("-Wp,-MT", a) ||
+                       str_startswith("-Wp,-MQ", a)) {
                 args.append(a, Arg_Local);
                 args.append(argv[++i], Arg_Local);
                 /* as above but with extra argument */


### PR DESCRIPTION
More fixes for Linux kernel build with -fdirectives-only. Some of the
kernel tools are passing the above options directly to the preprocessor
via -Wp. Need to make sure they are applied on the local cpp side.