### PR TITLE
do not package Clang internal headers in icecc-create-env

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -403,17 +403,6 @@ if test -n "$clang"; then
         touch $tempdir/fakeproc/proc/cpuinfo
         add_file $tempdir/fakeproc/proc/cpuinfo /proc/cpuinfo
     fi
-
-    # clang always uses its internal .h files
-    clangincludes=$($orig_clang -print-file-name=include/limits.h)
-    if test -z "$clangincludes"; then
-        echo $orig_clang cannot find its includes
-        exit 1
-    fi
-    clangincludes=$(dirname $(abs_path $clangincludes))
-    for file in $(find $clangincludes -type f); do
-      add_file "$file"
-    done
 fi
 
 # Do not do any prefix stripping on extra files, they (e.g. clang plugins) are usually


### PR DESCRIPTION
It doesn't seem to be actually needed (tested with Clang 8.0.0 and 4.0.1).
I have no idea why I added it, the commit doesn't say. Possibly
initially -frewrite-includes had a bug that necessitated this.