### PR TITLE
keep order of remote arguments, especially -gsplit-dwarf (#435)

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -293,7 +293,6 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
 {
     ArgumentsList args;
     string ofile;
-    string dwofile;
 
 #if CLIENT_DEBUG > 1
     trace() << "scanning arguments" << endl;
@@ -445,6 +444,7 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                 always_local = true;
                 args.append(a, Arg_Local);
             } else if (!strcmp(a, "-gsplit-dwarf")) {
+                args.append(a, Arg_Rest);
                 seen_split_dwarf = true;
             } else if (str_equal(a, "-x")) {
                 args.append(a, Arg_Rest);

--- a/client/local.cpp
+++ b/client/local.cpp
@@ -251,10 +251,6 @@ int build_local(CompileJob &job, MsgChannel *local_daemon, struct rusage *used)
     arguments.push_back(compiler_name);
     appendList(arguments, job.allFlags());
 
-    if (job.dwarfFissionEnabled()) {
-        arguments.push_back("-gsplit-dwarf");
-    }
-
     if (!job.inputFile().empty()) {
         arguments.push_back(job.inputFile());
     }

--- a/daemon/serve.cpp
+++ b/daemon/serve.cpp
@@ -286,18 +286,19 @@ int handle_connection(const string &basedir, CompileJob *job,
             }
         }
 
+        struct stat st;
+        if (stat(obj_file.c_str(), &st) == 0) {
+            job_stat[JobStatistics::out_uncompressed] += st.st_size;
+        }
+        if (stat(dwo_file.c_str(), &st) == 0) {
+            job_stat[JobStatistics::out_uncompressed] += st.st_size;
+            rmsg.have_dwo_file = true;
+        } else
+            rmsg.have_dwo_file = false;
+
         if (!client->send_msg(rmsg)) {
             log_info() << "write of result failed" << endl;
             throw myexception(EXIT_DISTCC_FAILED);
-        }
-
-        struct stat st;
-
-        if (!stat(obj_file.c_str(), &st)) {
-            job_stat[JobStatistics::out_uncompressed] += st.st_size;
-        }
-        if (!stat(dwo_file.c_str(), &st)) {
-            job_stat[JobStatistics::out_uncompressed] += st.st_size;
         }
 
         /* wake up parent and tell him that compile finished */

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -103,10 +103,9 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
     rmsg.out.erase(rmsg.out.begin(), rmsg.out.end());
     rmsg.out.erase(rmsg.out.begin(), rmsg.out.end());
 
-    std::list<string> list = j.remoteFlags();
-    appendList(list, j.restFlags());
+    std::list<string> list = j.nonLocalFlags();
 
-    if (j.dwarfFissionEnabled()) {
+    if (!IS_PROTOCOL_41(client) && j.dwarfFissionEnabled()) {
         list.push_back("-gsplit-dwarf");
     }
 
@@ -716,7 +715,6 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
                     struct timeval endtv;
                     gettimeofday(&endtv, 0);
                     rmsg.status = shell_exit_status(status);
-                    rmsg.have_dwo_file = j.dwarfFissionEnabled();
                     job_stat[JobStatistics::exit_code] = shell_exit_status(status);
                     job_stat[JobStatistics::real_msec] = ((endtv.tv_sec - starttv.tv_sec) * 1000)
                                                          + ((long(endtv.tv_usec) - long(starttv.tv_usec)) / 1000);

--- a/services/job.cpp
+++ b/services/job.cpp
@@ -56,6 +56,19 @@ list<string> CompileJob::restFlags() const
     return flags(Arg_Rest);
 }
 
+list<string> CompileJob::nonLocalFlags() const
+{
+    list<string> args;
+
+    for (ArgumentsList::const_iterator it = m_flags.begin(); it != m_flags.end(); ++it) {
+        if (it->second != Arg_Local) {
+            args.push_back(it->first);
+        }
+    }
+
+    return args;
+}
+
 list<string> CompileJob::allFlags() const
 {
     list<string> args;

--- a/services/job.h
+++ b/services/job.h
@@ -122,6 +122,7 @@ public:
     std::list<std::string> localFlags() const;
     std::list<std::string> remoteFlags() const;
     std::list<std::string> restFlags() const;
+    std::list<std::string> nonLocalFlags() const;
     std::list<std::string> allFlags() const;
 
     void setInputFile(const std::string &file)
@@ -144,6 +145,7 @@ public:
         return m_output_file;
     }
 
+    // Since protocol 41 this is just a shortcut saying that allFlags() contains "-gsplit-dwarf".
     void setDwarfFissionEnabled(bool flag)
     {
         m_dwarf_fission = flag;


### PR DESCRIPTION
This is based on pull requests #425. Both gcc and clang
have their peculiarities when handling -gsplit-dwarf depending
on the exact order of this and other -g arguments. So keep the order
the same and do not handle any of those arguments specially.

This technically changes the protocol, but let's keep it as part
of the recent version 41 change.