### PR TITLE
support compressing compiler tarballs using xz and zstd

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -19,10 +19,11 @@ esac
 usage ()
 {
     echo "Create compiler environment for distributed build."
-    echo "Usage: $0 <compiler_binary>"
+    echo "Usage: $0 <compiler_binary> [extra_options]"
     echo "For GCC, pass the the gcc binary, the matching g++ will be used automatically."
     echo "For Clang, pass the clang binary."
     echo "Use --addfile <file> to add extra files."
+    echo "Use --compression <type> to set tarball type (none,gzip,bzip2,zstd,xz)."
     echo "For backwards compatibility, the following is also supported:"
     echo "$0 --gcc <gcc_path> <g++_path>"
     echo "$0 --clang <clang_path>"
@@ -314,10 +315,16 @@ else
         exit 1
     fi
     shift
-    if test -n "$1" -a "x$1" != "x--addfile"; then
-        # (backwards) compatibility, assume the second argument is the C++ compiler
-        added_gxx=$1
-        shift
+    if test -n "$1"; then
+        case "$1" in
+            --*)
+                ;; # an option, ignore
+            *)
+                # (backwards) compatibility, assume the second argument is the C++ compiler
+                added_gxx=$1
+                shift
+                ;;
+        esac
     fi
     if test -n "$gcc" -a -z "$added_gxx"; then
         # guess g++ from gcc
@@ -364,15 +371,63 @@ if test -n "$clang"; then
 fi
 
 extrafiles=
-while test "x$1" = "x--addfile"; do
-    shift
-    extrafiles="$extrafiles $1"
+compress_program=gzip
+compress_ext=.gz
+compress_args=
+
+while test -n "$1"; do
+
+    if test "x$1" = "x--addfile"; then
+        shift
+        extrafiles="$extrafiles $1"
+    elif test "x$1" = "x--compression"; then
+        shift
+        case "$1" in
+            none)
+                compress_ext=
+                compress_program=cat
+                ;;
+            gzip|gz)
+                compress_ext=.gz
+                compress_program=gzip
+                ;;
+            bzip2|bz2)
+                compress_ext=.bz2
+                compress_program=bzip2
+                ;;
+            zstd)
+                compress_ext=.zst
+                compress_program=zstd
+                # threads
+                compress_args=-T0
+                ;;
+            xz)
+                compress_ext=.xz
+                compress_program=xz
+                # threads
+                compress_args=-T0
+                if test -n "$ICECC_TESTS"; then
+                    compress_args="-T0 -0"
+                fi
+                ;;
+            *)
+                echo "Unknown compression type '$1'."
+                exit 1
+                ;;
+        esac
+    else
+        echo "Unknown argument '$1'"
+        exit 1
+    fi
+
     shift
 done
 
-if test -n "$1"; then
-    echo "Unknown argument '$1'"
-    exit 1
+if test -n "$compress_program"; then
+    if ! command -v "$compress_program" >/dev/null; then
+        echo "Cannot find compression program '$compress_program'."
+        exit 1
+    fi
 fi
 
 tempdir=$(mktemp -d /tmp/iceccenvXXXXXX)
@@ -524,18 +579,19 @@ md5=$(for i in $target_files; do $md5sum $tempdir/$i; done | sed -e "s# $tempdir
   echo "Couldn't compute MD5 sum."
   exit 2
 }
-echo "creating $md5.tar.gz"
+
+echo "creating $md5.tar$compress_ext"
 mydir=$(pwd)
 cd $tempdir
-tar -czh --numeric-owner -f "$md5".tar.gz $target_files || {
+tar -ch --numeric-owner -f - $target_files | "$compress_program" $compress_args > "$md5".tar"$compress_ext" || {
   echo "Couldn't create archive"
   exit 3
 }
-mv "$md5".tar.gz "$mydir"/
+mv "$md5".tar"$compress_ext" "$mydir"/
 cd ..
 rm -rf $tempdir
 rm -f $tmp_ld_so_conf
 
 # Print the tarball name to fd 5 (if it's open, created by whatever has invoked this)
-( echo $md5.tar.gz >&5 ) 2>/dev/null
+( echo $md5.tar"$compress_ext" >&5 ) 2>/dev/null
 exit 0

--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -812,7 +812,7 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
         GetCSMsg getcs(envs, fake_filename, job.language(), torepeat,
                        job.targetPlatform(), job.argumentFlags(),
                        preferred_host ? preferred_host : string(),
-                       minimalRemoteVersion(job));
+                       minimalRemoteVersion(job), 0);
 
         trace() << "asking for host to use" << endl;
         if (!local_daemon->send_msg(getcs)) {
@@ -866,7 +866,7 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
         GetCSMsg getcs(envs, get_absfilename(job.inputFile()), job.language(), torepeat,
                        job.targetPlatform(), job.argumentFlags(),
                        preferred_host ? preferred_host : string(),
-                       minimalRemoteVersion(job));
+                       minimalRemoteVersion(job), 0);
 
 
         if (!local_daemon->send_msg(getcs)) {

--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -762,6 +762,18 @@ static int minimalRemoteVersion( const CompileJob& job)
     return version;
 }
 
+static unsigned int requiredRemoteFeatures()
+{
+    unsigned int features = 0;
+    if (const char* icecc_env_compression = getenv( "ICECC_ENV_COMPRESSION" )) {
+        if( strcmp( icecc_env_compression, "xz" ) == 0 )
+            features = features | NODE_FEATURE_ENV_XZ;
+        if( strcmp( icecc_env_compression, "zstd" ) == 0 )
+            features = features | NODE_FEATURE_ENV_ZSTD;
+    }
+    return features;
+}
+
 int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &_envs, int permill)
 {
     srand(time(0) + getpid());
@@ -812,7 +824,7 @@ int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &
         GetCSMsg getcs(envs, fake_filename, job.language(), torepeat,
                        job.targetPlatform(), job.argumentFlags(),
                        preferred_host ? preferred_host : string(),
-                       minimalRemoteVersion(job), 0);
+                       minimalRemoteVersion(job), requiredRemoteFeatures());
 
         trace() << "asking for host to use" << endl;
         if (!local_daemon->send_msg(getcs)) {

--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,6 @@ AC_CHECK_HEADERS([netinet/tcp_var.h], [], [],
 ])
 
 AC_CHECK_HEADERS([sys/user.h])
-AC_CHECK_HEADERS([archive.h, archive_entry.h])
 
 ######################################################################
 dnl Checks for types
@@ -196,9 +195,39 @@ AC_SUBST(ZSTD_LDADD)
 AC_CHECK_LIB([dl], [dlsym], [DL_LDADD=-ldl])
 AC_SUBST([DL_LDADD])
 
+AC_CHECK_HEADERS([archive.h, archive_entry.h])
 AC_CHECK_LIB(archive, archive_read_data_block, ARCHIVE_LDADD=-larchive,
     AC_MSG_ERROR([Could not find libarchive library - please install libarchive-devel]))
 AC_SUBST(ARCHIVE_LDADD)
+
+AC_MSG_CHECKING([whether libarchive has archive_read_support_filter_xz()])
+AC_TRY_COMPILE(
+    [
+    #include <archive.h>
+    ],
+    [
+        struct archive *a;
+        archive_read_support_filter_xz(a);
+    ],
+    [
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_LIBARCHIVE_XZ, 1, [Whether libarchive has archive_read_support_filter_xz()])
+    ],
+    [ AC_MSG_RESULT(no) ])
+AC_MSG_CHECKING([whether libarchive has archive_read_support_filter_zstd()])
+AC_TRY_COMPILE(
+    [
+    #include <archive.h>
+    ],
+    [
+        struct archive *a;
+        archive_read_support_filter_zstd(a);
+    ],
+    [
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_LIBARCHIVE_ZSTD, 1, [Whether libarchive has archive_read_support_filter_zstd()])
+    ],
+    [ AC_MSG_RESULT(no) ])
 
 # In DragonFlyBSD daemon needs to be linked against libkinfo.
 case $host_os in

--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -217,7 +217,8 @@ Environments available_environmnents(const string &basedir)
 
 // Returns fd for icecc-create-env output
 int start_create_env(const string &basedir, uid_t user_uid, gid_t user_gid,
-                     const std::string &compiler, const list<string> &extrafiles)
+                     const std::string &compiler, const list<string> &extrafiles,
+                     const std::string &compression)
 {
     string nativedir = basedir + "/native/";
     if (mkdir(nativedir.c_str(), 0775) && errno != EEXIST) {
@@ -310,6 +311,11 @@ int start_create_env(const string &basedir, uid_t user_uid, gid_t user_gid,
     }
 
     argv[pos++] = NULL;
+
+    if (!compression.empty()) {
+        // icecc will read it from ICECC_ENV_COMPRESSION, we are in a forked process, so simply set it
+        setenv( "ICECC_ENV_COMPRESSION", compression.c_str(), 1 );
+    }
 
     if (!exec_and_wait(argv)) {
         log_error() << BINDIR "/icecc --build-native failed" << endl;

--- a/daemon/environment.h
+++ b/daemon/environment.h
@@ -32,7 +32,8 @@ class MsgChannel;
 extern bool cleanup_cache(const std::string &basedir, uid_t user_uid, gid_t user_gid);
 extern int start_create_env(const std::string &basedir,
                             uid_t user_uid, gid_t user_gid,
-                            const std::string &compiler, const std::list<std::string> &extrafiles);
+                            const std::string &compiler, const std::list<std::string> &extrafiles,
+                            const std::string &compression);
 extern size_t finish_create_env(int pipe, const std::string &basedir, std::string &native_environment);
 Environments available_environmnents(const std::string &basename);
 extern pid_t start_install_environment(const std::string &basename,

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -752,7 +752,7 @@ bool Daemon::send_scheduler(const Msg& msg)
 bool Daemon::reannounce_environments()
 {
     log_info() << "reannounce_environments " << endl;
-    LoginMsg lmsg(0, nodename, "");
+    LoginMsg lmsg(0, nodename, "", 0);
     lmsg.envs = available_environmnents(envbasedir);
     return send_scheduler(lmsg);
 }
@@ -2127,7 +2127,7 @@ bool Daemon::reconnect()
     gettimeofday(&last_stat, 0);
     icecream_load = 0;
 
-    LoginMsg lmsg(daemon_port, determine_nodename(), machine_name);
+    LoginMsg lmsg(daemon_port, determine_nodename(), machine_name, 0);
     lmsg.envs = available_environmnents(envbasedir);
     lmsg.max_kids = max_kids;
     lmsg.noremote = noremote;

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -78,6 +78,8 @@
 #  include <cap-ng.h>
 #endif
 
+#include <archive.h>
+
 #include <deque>
 #include <map>
 #include <algorithm>
@@ -480,6 +482,7 @@ struct Daemon {
     string schedname;
     int scheduler_port;
     int daemon_port;
+    unsigned int supported_features;
 
     int max_scheduler_pong;
     int max_scheduler_ping;
@@ -554,6 +557,7 @@ struct Daemon {
     string dump_internals() const;
     string determine_nodename();
     void determine_system();
+    void determine_supported_features();
     bool maybe_stats(bool force_check = false);
     bool send_scheduler(const Msg &msg) __attribute_warn_unused_result__;
     void close_scheduler();
@@ -733,6 +737,31 @@ string Daemon::determine_nodename()
     return nodename;
 }
 
+void Daemon::determine_supported_features()
+{
+    supported_features = 0;
+    struct archive* a = archive_read_new();
+    static bool test_disable = false;
+    // Make one of the two remotes in tests say it doesn't support xz/zstd tarballs.
+    if( getenv( "ICECC_TESTS" ) != NULL && nodename == "remoteice2" )
+        test_disable = true;
+    (void)test_disable;
+#ifdef HAVE_LIBARCHIVE_XZ
+    if( !test_disable && archive_read_support_filter_xz(a) >= ARCHIVE_WARN ) // includes ARCHIVE_OK
+        supported_features = supported_features | NODE_FEATURE_ENV_XZ;
+#endif
+#ifdef HAVE_LIBARCHIVE_ZSTD
+    if( !test_disable && archive_read_support_filter_zstd(a) >= ARCHIVE_WARN ) // includes ARCHIVE_OK
+        supported_features = supported_features | NODE_FEATURE_ENV_ZSTD;
+#endif
+    // sanity checks
+    if( archive_read_support_filter_gzip(a) < ARCHIVE_WARN ) // error
+        log_error() << "No support for uncompressing gzip available." << endl;
+    if( archive_read_support_format_tar(a) < ARCHIVE_WARN ) // error
+        log_error() << "No support for unpacking tar available." << endl;
+    archive_read_free(a);
+}
+
 bool Daemon::send_scheduler(const Msg& msg)
 {
     if (!scheduler) {
@@ -752,7 +781,7 @@ bool Daemon::send_scheduler(const Msg& msg)
 bool Daemon::reannounce_environments()
 {
     log_info() << "reannounce_environments " << endl;
-    LoginMsg lmsg(0, nodename, "", 0);
+    LoginMsg lmsg(0, nodename, "", supported_features);
     lmsg.envs = available_environmnents(envbasedir);
     return send_scheduler(lmsg);
 }
@@ -890,6 +919,8 @@ string Daemon::dump_internals() const
     }
 
     result += "  Current kids: " + toString(current_kids) + " (max: " + toString(max_kids) + ")\n";
+
+    result += "  Supported features: " + supported_features_to_string(supported_features) + "\n";
 
     if (scheduler) {
         result += "  Scheduler protocol: " + toString(scheduler->protocol) + "\n";
@@ -1291,7 +1322,7 @@ bool Daemon::handle_get_native_env(Client *client, GetNativeEnvMsg *msg)
         filetimes[cppcompiler] = st.st_mtime;
     }
 
-    env_key = ccompiler;
+    env_key = msg->compression + ":" + ccompiler;
     for (list<string>::const_iterator it = msg->extrafiles.begin();
             it != msg->extrafiles.end(); ++it) {
         env_key += ':';
@@ -1337,7 +1368,8 @@ bool Daemon::handle_get_native_env(Client *client, GetNativeEnvMsg *msg)
         if (!env.create_env_pipe) { // start creating it only if not already in progress
             env.filetimes = filetimes;
             trace() << "start_create_env " << env_key << endl;
-            env.create_env_pipe = start_create_env(envbasedir, user_uid, user_gid, ccompiler, msg->extrafiles);
+            env.create_env_pipe = start_create_env(envbasedir, user_uid, user_gid, ccompiler,
+                msg->extrafiles, msg->compression);
         } else {
             trace() << "waiting for already running create_env " << env_key << endl;
         }
@@ -2127,7 +2159,7 @@ bool Daemon::reconnect()
     gettimeofday(&last_stat, 0);
     icecream_load = 0;
 
-    LoginMsg lmsg(daemon_port, determine_nodename(), machine_name, 0);
+    LoginMsg lmsg(daemon_port, determine_nodename(), machine_name, supported_features);
     lmsg.envs = available_environmnents(envbasedir);
     lmsg.max_kids = max_kids;
     lmsg.noremote = noremote;
@@ -2410,6 +2442,9 @@ int main(int argc, char **argv)
     }
 
     log_info() << "allowing up to " << max_kids << " active jobs" << endl;
+
+    d.determine_supported_features();
+    log_info() << "supported features: " << supported_features_to_string(d.supported_features) << endl;
 
     int ret;
 

--- a/scheduler/compileserver.h
+++ b/scheduler/compileserver.h
@@ -101,6 +101,9 @@ public:
     bool chrootPossible() const;
     void setChrootPossible(const bool possible);
 
+    bool featuresSupported(unsigned int features) const;
+    void setSupportedFeatures(unsigned int features);
+
     int clientCount() const;
     void setClientCount( int clientCount );
     int submittedJobsCount() const;
@@ -162,6 +165,7 @@ private:
     State m_state;
     Type m_type;
     bool m_chrootPossible;
+    unsigned int m_featuresSupported;
     int m_clientCount; // number of client connections the daemon has
     int m_submittedJobsCount;
     unsigned int m_lastPickId;

--- a/scheduler/job.cpp
+++ b/scheduler/job.cpp
@@ -41,6 +41,7 @@ Job::Job(const unsigned int _id, CompileServer *subm)
     , m_language()
     , m_preferredHost()
     , m_minimalHostVersion(0)
+    , m_requiredFeatures(0)
 {
     m_submitter->submittedJobsIncrement();
 }
@@ -216,4 +217,14 @@ int Job::minimalHostVersion() const
 void Job::setMinimalHostVersion(int version)
 {
     m_minimalHostVersion = version;
+}
+
+unsigned int Job::requiredFeatures() const
+{
+    return m_requiredFeatures;
+}
+
+void Job::setRequiredFeatures(unsigned int features)
+{
+    m_requiredFeatures = features;
 }

--- a/scheduler/job.h
+++ b/scheduler/job.h
@@ -93,6 +93,9 @@ public:
     int minimalHostVersion() const;
     void setMinimalHostVersion( int version );
 
+    unsigned int requiredFeatures() const;
+    void setRequiredFeatures(unsigned int features);
+
 private:
     const unsigned int m_id;
     unsigned int m_localClientId;
@@ -117,6 +120,7 @@ private:
     std::string m_language; // for debugging
     std::string m_preferredHost; // for debugging daemons
     int m_minimalHostVersion; // minimal version required for the the remote server
+    unsigned int m_requiredFeatures; // flags the job requires on the remote server
 };
 
 #endif

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -456,6 +456,7 @@ static bool handle_cs_request(MsgChannel *cs, Msg *_m)
         job->setLocalClientId(m->client_id);
         job->setPreferredHost(m->preferred_host);
         job->setMinimalHostVersion(m->minimal_host_version);
+        job->setRequiredFeatures(m->required_features);
         enqueue_job_request(job);
         std::ostream &dbg = log_info();
         dbg << "NEW " << job->id() << " client="
@@ -1027,6 +1028,7 @@ static bool handle_login(CompileServer *cs, Msg *_m)
 
     cs->setHostPlatform(m->host_platform);
     cs->setChrootPossible(m->chroot_possible);
+    cs->setSupportedFeatures(m->supported_features);
     cs->pick_new_id();
 
     for (list<string>::const_iterator it = block_css.begin(); it != block_css.end(); ++it)
@@ -1034,16 +1036,13 @@ static bool handle_login(CompileServer *cs, Msg *_m)
             return false;
         }
 
-    dbg << "login " << m->nodename << " protocol version: " << cs->protocol;
-#if 1
-    dbg << " [";
-
+    dbg << "login " << m->nodename << " protocol version: " << cs->protocol
+        << " features: " << supported_features_to_string(m->supported_features)
+        << " [";
     for (Environments::const_iterator it = m->envs.begin(); it != m->envs.end(); ++it) {
         dbg << it->second << "(" << it->first << "), ";
     }
-
     dbg << "]" << endl;
-#endif
 
     handle_monitor_stats(cs);
 

--- a/services/comm.cpp
+++ b/services/comm.cpp
@@ -1949,6 +1949,11 @@ void GetCSMsg::fill_from_channel(MsgChannel *c)
     if (IS_PROTOCOL_39(c)) {
         *c >> client_count;
     }
+
+    required_features = 0;
+    if (IS_PROTOCOL_42(c)) {
+        *c >> required_features;
+    }
 }
 
 void GetCSMsg::send_to_channel(MsgChannel *c) const
@@ -1975,6 +1980,9 @@ void GetCSMsg::send_to_channel(MsgChannel *c) const
 
     if (IS_PROTOCOL_39(c)) {
         *c << client_count;
+    }
+    if (IS_PROTOCOL_42(c)) {
+        *c << required_features;
     }
 }
 
@@ -2336,7 +2344,8 @@ void JobDoneMsg::set_job_id( uint32_t jobId )
     flags &= ~ (uint32_t) UnknownJobId;
 }
 
-LoginMsg::LoginMsg(unsigned int myport, const std::string &_nodename, const std::string &_host_platform)
+LoginMsg::LoginMsg(unsigned int myport, const std::string &_nodename, const std::string &_host_platform,
+    unsigned int myfeatures)
     : Msg(M_LOGIN)
     , port(myport)
     , max_kids(0)
@@ -2344,6 +2353,7 @@ LoginMsg::LoginMsg(unsigned int myport, const std::string &_nodename, const std:
     , chroot_possible(false)
     , nodename(_nodename)
     , host_platform(_host_platform)
+    , supported_features(myfeatures)
 {
 #ifdef HAVE_LIBCAP_NG
     chroot_possible = capng_have_capability(CAPNG_EFFECTIVE, CAP_SYS_CHROOT);
@@ -2371,6 +2381,11 @@ void LoginMsg::fill_from_channel(MsgChannel *c)
     }
 
     noremote = (net_noremote != 0);
+
+    supported_features = 0;
+    if (IS_PROTOCOL_42(c)) {
+        *c >> supported_features;
+    }
 }
 
 void LoginMsg::send_to_channel(MsgChannel *c) const
@@ -2385,6 +2400,9 @@ void LoginMsg::send_to_channel(MsgChannel *c) const
 
     if (IS_PROTOCOL_26(c)) {
         *c << noremote;
+    }
+    if (IS_PROTOCOL_42(c)) {
+        *c << supported_features;
     }
 }
 

--- a/services/comm.h
+++ b/services/comm.h
@@ -148,6 +148,11 @@ enum Compression {
     C_ZSTD = 1
 };
 
+// The remote node is capable of unpacking environment compressed as .tar.xz .
+const int NODE_FEATURE_ENV_XZ = ( 1 << 0 );
+// The remote node is capable of unpacking environment compressed as .tar.zst .
+const int NODE_FEATURE_ENV_ZSTD = ( 1 << 1 );
+
 class MsgChannel;
 
 // a list of pairs of host platform, filename
@@ -420,19 +425,7 @@ public:
              std::string _target, unsigned int _arg_flags,
              const std::string &host, int _minimal_host_version,
              unsigned int _required_features,
-             unsigned int _client_count = 0)
-        : Msg(M_GET_CS)
-        , versions(envs)
-        , filename(f)
-        , lang(_lang)
-        , count(_count)
-        , target(_target)
-        , arg_flags(_arg_flags)
-        , client_id(0)
-        , preferred_host(host)
-        , minimal_host_version(_minimal_host_version)
-        , required_features(_required_features)
-        , client_count(_client_count) {}
+             unsigned int _client_count = 0);
 
     virtual void fill_from_channel(MsgChannel *c);
     virtual void send_to_channel(MsgChannel *c) const;
@@ -501,16 +494,20 @@ public:
     GetNativeEnvMsg()
         : Msg(M_GET_NATIVE_ENV) {}
 
-    GetNativeEnvMsg(const std::string &c, const std::list<std::string> &e)
+    GetNativeEnvMsg(const std::string &c, const std::list<std::string> &e,
+        const std::string &comp)
         : Msg(M_GET_NATIVE_ENV)
         , compiler(c)
-        , extrafiles(e) {}
+        , extrafiles(e)
+        , compression(comp)
+        {}
 
     virtual void fill_from_channel(MsgChannel *c);
     virtual void send_to_channel(MsgChannel *c) const;
 
     std::string compiler; // "gcc", "clang" or the actual binary
     std::list<std::string> extrafiles;
+    std::string compression; // "" (=default), "none", "gzip", "xz", etc.
 };
 
 class UseNativeEnvMsg : public Msg

--- a/services/comm.h
+++ b/services/comm.h
@@ -36,7 +36,7 @@
 #include "job.h"
 
 // if you increase the PROTOCOL_VERSION, add a macro below and use that
-#define PROTOCOL_VERSION 41
+#define PROTOCOL_VERSION 42
 // if you increase the MIN_PROTOCOL_VERSION, comment out macros below and clean up the code
 #define MIN_PROTOCOL_VERSION 21
 
@@ -66,6 +66,7 @@
 #define IS_PROTOCOL_39(c) ((c)->protocol >= 39)
 #define IS_PROTOCOL_40(c) ((c)->protocol >= 40)
 #define IS_PROTOCOL_41(c) ((c)->protocol >= 41)
+#define IS_PROTOCOL_42(c) ((c)->protocol >= 42)
 
 // Terms used:
 // S  = scheduler
@@ -418,6 +419,7 @@ public:
              CompileJob::Language _lang, unsigned int _count,
              std::string _target, unsigned int _arg_flags,
              const std::string &host, int _minimal_host_version,
+             unsigned int _required_features,
              unsigned int _client_count = 0)
         : Msg(M_GET_CS)
         , versions(envs)
@@ -429,6 +431,7 @@ public:
         , client_id(0)
         , preferred_host(host)
         , minimal_host_version(_minimal_host_version)
+        , required_features(_required_features)
         , client_count(_client_count) {}
 
     virtual void fill_from_channel(MsgChannel *c);
@@ -443,6 +446,7 @@ public:
     uint32_t client_id;
     std::string preferred_host;
     int minimal_host_version;
+    uint32_t required_features;
     uint32_t client_count; // number of CS -> C connections at the moment
 };
 
@@ -709,7 +713,8 @@ public:
 class LoginMsg : public Msg
 {
 public:
-    LoginMsg(unsigned int myport, const std::string &_nodename, const std::string &_host_platform);
+    LoginMsg(unsigned int myport, const std::string &_nodename, const std::string &_host_platform,
+             unsigned int my_features);
     LoginMsg()
         : Msg(M_LOGIN)
         , port(0) {}
@@ -724,6 +729,7 @@ public:
     bool chroot_possible;
     std::string nodename;
     std::string host_platform;
+    uint32_t supported_features; // bitmask of various features the node supports
 };
 
 class ConfCSMsg : public Msg

--- a/services/util.cpp
+++ b/services/util.cpp
@@ -144,9 +144,13 @@ bool pollfd_is_set(const vector<pollfd>& pollfds, int fd, int flags, bool check_
     return false;
 }
 
-string supported_features_to_string(unsigned int)
+string supported_features_to_string(unsigned int features)
 {
     string ret;
+    if( features & NODE_FEATURE_ENV_XZ )
+        ret += " env_xz";
+    if( features & NODE_FEATURE_ENV_ZSTD )
+        ret += " env_zstd";
     if( ret.empty())
         ret = "--";
     else

--- a/services/util.cpp
+++ b/services/util.cpp
@@ -26,6 +26,8 @@
 #include <cassert>
 #include <cstring>
 
+#include "comm.h"
+
 using namespace std;
 
 /**
@@ -140,4 +142,14 @@ bool pollfd_is_set(const vector<pollfd>& pollfds, int fd, int flags, bool check_
         }
     }
     return false;
+}
+
+string supported_features_to_string(unsigned int)
+{
+    string ret;
+    if( ret.empty())
+        ret = "--";
+    else
+        ret.erase( 0, 1 ); // remove leading " "
+    return ret;
 }

--- a/services/util.h
+++ b/services/util.h
@@ -45,4 +45,6 @@ inline T ignore_result(T x __attribute__((unused)))
 // If check_errors is set, then errors such as POLLHUP are also considered as matching.
 bool pollfd_is_set(const std::vector<pollfd>& pollfds, int fd, int flags, bool check_errors = true);
 
+std::string supported_features_to_string(unsigned int features);
+
 #endif


### PR DESCRIPTION
The theory for this is #433 . With this version of scheduler and daemon this should handle gracefully even nodes that don't support unpacking xz/zstd. Where "gracefully" means compilation using xz/zstd will ignore them completely, but I find that good enough. So far gzip is still the default, so this requires ICECC_ENV_COMPRESSION=xz/zstd/none set. Maybe some day I'll feel like making an appropriate compression method detection automatic based on what's available in the cluster.
