### PR TITLE
add --enable-debug to configure, for developer builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,20 @@ if test "$GCC" = yes; then
     AC_MSG_NOTICE([Adding gcc options: $CFLAGS])
 fi
 
+AC_ARG_ENABLE(debug,
+    AS_HELP_STRING([--enable-debug],
+        [Enable debug mode (enable asserts, disable optimizations).]))
+AC_MSG_CHECKING([whether to enable debug module])
+if test "$enable_debug" = "yes"; then
+    CFLAGS="$CFLAGS -g -O0"
+    CXXFLAGS="$CXXFLAGS -g -O0"
+    AC_MSG_RESULT(yes)
+else
+    CFLAGS="$CFLAGS -DNDEBUG"
+    CXXFLAGS="$CXXFLAGS -DNDEBUG"
+    AC_MSG_RESULT(no)
+fi
+
 AC_PROG_MAKE_SET
 AC_PROG_INSTALL
 AC_C_INLINE

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -1592,6 +1592,7 @@ bool Daemon::handle_blacklist_host_env(Client *client, Msg *msg)
     // just forward
     assert(dynamic_cast<BlacklistHostEnvMsg *>(msg));
     assert(client);
+    (void)client;
 
     if (!scheduler) {
         return false;

--- a/services/logging.h
+++ b/services/logging.h
@@ -137,8 +137,6 @@ class log_block
 public:
     log_block(const char *label = 0)
     {
-#ifndef NDEBUG
-
         for (unsigned i = 0; i < nesting; ++i) {
             log_info() << "  ";
         }
@@ -148,12 +146,10 @@ public:
         m_label = strdup(label ? label : "");
         ++nesting;
         gettimeofday(&m_start, 0);
-#endif
     }
 
     ~log_block()
     {
-#ifndef NDEBUG
         timeval end;
         gettimeofday(&end, 0);
 
@@ -168,7 +164,6 @@ public:
                    << "ms>\n";
 
         free(m_label);
-#endif
     }
 };
 


### PR DESCRIPTION
Currently normal production builds can abort on asserts, see e.g. #452.
So now by default a production build is done, without asserts,
for developer builds use --enable-debug, which will enable asserts
and disable compiler optimizations. The ICECC_DEBUG= mechanism is
unaffected.