### PR TITLE
icecc-create-env: ensure that target directories of symbolic links get created

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -527,7 +527,10 @@ fi
 
 # special case for weird multilib setups
 for dir in /lib /lib64 /usr/lib /usr/lib64; do
-    test -L $dir && cp -Pp $dir $tempdir$dir
+    if [ -L $dir ]; then
+        cp -Pp $dir $tempdir$dir
+        mkdir -p $tempdir/$(file $dir | cut -d' ' -f5-)
+    fi
 done
 
 new_target_files=


### PR DESCRIPTION
This is an attempt to fix #464. I am not 100 % certain that this is the correct way to tackle the issue, so I'm open for constructive feedback.