### PR TITLE
 Improve error messages for exec() calls 

### DIFF
--- a/client/cpp.cpp
+++ b/client/cpp.cpp
@@ -200,6 +200,8 @@ pid_t call_cpp(CompileJob &job, int fdwrite, int fdread)
     dcc_increment_safeguard(SafeguardStepCompiler);
     execv(argv[0], argv);
     int exitcode = ( errno == ENOENT ? 127 : 126 );
-    log_perror("execv failed");
+    ostringstream errmsg;
+    errmsg << "execv " << argv[0] << " failed";
+    log_perror(errmsg.str());
     _exit(exitcode);
 }

--- a/client/local.cpp
+++ b/client/local.cpp
@@ -312,7 +312,9 @@ int build_local(CompileJob &job, MsgChannel *local_daemon, struct rusage *used)
 
         execv(argv[0], &argv[0]);
         int exitcode = ( errno == ENOENT ? 127 : 126 );
-        log_perror("execv failed");
+        ostringstream errmsg;
+        errmsg << "execv " << argv[0] << " failed";
+        log_perror(errmsg.str());
 
         dcc_unlock();
 

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -196,7 +196,9 @@ static int create_native(char **args)
 
     argv.push_back(NULL);
     execv(argv[0], argv.data());
-    log_perror("execv failed");
+    ostringstream errmsg;
+    errmsg << "execv " << argv[0] << " failed";
+    log_perror(errmsg.str());
     return -1;
 }
 

--- a/compilerwrapper/compilerwrapper.cpp
+++ b/compilerwrapper/compilerwrapper.cpp
@@ -34,6 +34,7 @@ if clang is to be used as well, that will either call clang or the real gcc.
 Which one depends on an extra argument added by icecream.
 */
 
+#include <sstream>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -143,6 +144,8 @@ int main(int argc, char *argv[])
     fprintf(stderr, "\n");
 #endif
     execv(args[0], args);
-    fprintf(stderr, "execv failed\n");
+    std::ostringstream errmsg;
+    errmsg << "execv " << args[0] << " failed";
+    perror(errmsg.str().c_str());
     exit(1);
 }

--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -119,7 +119,9 @@ static bool exec_and_wait(const char *const argv[])
 
     // child
     execv(argv[0], const_cast<char * const *>(argv));
-    log_perror("execv failed");
+    ostringstream errmsg;
+    errmsg << "execv " << argv[0] << " failed";
+    log_perror(errmsg.str());
     _exit(-1);
 }
 
@@ -636,7 +638,9 @@ size_t remove_environment(const string &basename, const string &env)
     argv[4] = NULL;
 
     execv(argv[0], argv);
-    log_perror("execv failed");
+    ostringstream errmsg;
+    errmsg << "execv " << argv[0] << " failed";
+    log_perror(errmsg.str());
     _exit(-1);
 }
 
@@ -763,7 +767,7 @@ bool verify_env(MsgChannel *client, const string &basedir, const string &target,
     reset_debug();
     chdir_to_environment(client, dirname, user_uid, user_gid);
     execl("bin/true", "bin/true", (void*)NULL);
-    log_perror("execl failed");
+    log_perror("execl bin/true failed");
     _exit(-1);
 
 }

--- a/services/logging.h
+++ b/services/logging.h
@@ -118,6 +118,11 @@ static inline std::ostream & log_perror(const char *prefix)
     return log_errno(prefix, errno);
 }
 
+static inline std::ostream & log_perror(const std::string &prefix)
+{
+    return log_perror(prefix.c_str());
+}
+
 static inline std::ostream & log_errno_trace(const char *prefix, int tmp_errno)
 {
     return trace() << prefix << "(Error: " << strerror(tmp_errno) << ")" << std::endl;


### PR DESCRIPTION
If `exec()` fails, the user should be told which binary was supposed to be
executed.