### PR TITLE
make sending in small 10k chunks controlled by ICECC_SLOW_NETWORK (#407)

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -99,6 +99,7 @@ static void dcc_show_usage(void)
         "   ICECC_CARET_WORKAROUND     set to 1 or 0 to override gcc show caret workaround.\n"
         "   ICECC_COMPRESSION          if set, the libzstd compression level (1 to 19, default: 1)\n"
         "   ICECC_ENV_COMPRESSION      compression type for icecc environments [none|gzip|bzip2|zstd|xz]\n"
+        "   ICECC_SLOW_NETWORK         set to 1 to send network data in smaller chunks\n"
         );
 }
 


### PR DESCRIPTION
With limiting the rate of local preprocessors in #486 the change from #407
should be much less needed and IMO it's now generally a needless slowdown
that causes more system calls, possibly more context switches, etc.
So change back to using large chunks by default and use the smaller ones
only if ICECC_SLOW_NETWORK=1 is set.