### PR TITLE
Remove superfluous lstat()

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -200,7 +200,7 @@ static int create_native(char **args)
     ostringstream errmsg;
     errmsg << "execv " << argv[0] << " failed";
     log_perror(errmsg.str());
-    return -1;
+    return 1;
 }
 
 static MsgChannel* get_local_daemon()

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -175,12 +175,6 @@ static int create_native(char **args)
     }
 
     vector<char*> argv;
-    struct stat st;
-
-    if (lstat(BINDIR "/icecc-create-env", &st)) {
-        log_error() << BINDIR "/icecc-create-env does not exist" << endl;
-        return 1;
-    }
 
     argv.push_back(strdup(BINDIR "/icecc-create-env"));
     argv.push_back(strdup(compiler.c_str()));


### PR DESCRIPTION
Some minor cleanup in the client code. No need to call `lstat()` on a file that you're going to `execv()` immediately afterwards. `log_perror()` will give a meaningful error message if the latter fails.