### PR TITLE
remove icecc-create-env's handling of 'weird multilib setups' (#464)

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -534,11 +534,6 @@ if test -f /etc/ld.so.conf; then
   add_file $tmp_ld_so_conf /etc/ld.so.conf
 fi
 
-# special case for weird multilib setups
-for dir in /lib /lib64 /usr/lib /usr/lib64; do
-    test -L $dir && cp -Pp $dir $tempdir$dir
-done
-
 new_target_files=
 for i in $target_files; do
  case $i in


### PR DESCRIPTION
This comes from 2008's ab934f2236, which says it's for gentoo, but
doesn't say more. It doesn't seem actually needed AFAICT, and it breaks
Fedora with /lib64 being a symlink, and it's unclear what this was
trying to solve or whether that is still a problem. So remove
and if this change breaks it for something, at least they'll provide
information on why this would be needed.