### PR TITLE
always make daemons listen on the loopback interface

### DIFF
--- a/services/comm.cpp
+++ b/services/comm.cpp
@@ -1473,17 +1473,17 @@ static int open_send_broadcast(int port, const char* buf, int size)
         static bool in_tests = getenv( "ICECC_TESTS" ) != NULL;
         if (!in_tests) {
             if (ntohl(((struct sockaddr_in *) addr->ifa_addr)->sin_addr.s_addr) == 0x7f000001) {
-                trace() << "ignoring localhost " << addr->ifa_name << endl;
+                trace() << "ignoring localhost " << addr->ifa_name << " for broadcast" << endl;
                 continue;
             }
 
             if ((addr->ifa_flags & IFF_POINTOPOINT) || !(addr->ifa_flags & IFF_BROADCAST)) {
-                log_info() << "ignoring tunnels " << addr->ifa_name << endl;
+                log_info() << "ignoring tunnels " << addr->ifa_name << " for broadcast" << endl;
                 continue;
             }
         } else {
             if (ntohl(((struct sockaddr_in *) addr->ifa_addr)->sin_addr.s_addr) != 0x7f000001) {
-                trace() << "ignoring non-localhost " << addr->ifa_name << endl;
+                trace() << "ignoring non-localhost " << addr->ifa_name << " for broadcast" << endl;
                 continue;
             }
         }

--- a/services/getifaddrs.cpp
+++ b/services/getifaddrs.cpp
@@ -296,10 +296,15 @@ bool build_address_for_interface(struct sockaddr_in &myaddr, const std::string &
     // Pre-fill the output parameter with the default address (port, INADDR_ANY)
     myaddr.sin_family = AF_INET;
     myaddr.sin_port = htons(port);
-    myaddr.sin_addr.s_addr = INADDR_ANY;
+    myaddr.sin_addr.s_addr = htonl( INADDR_ANY );
 
     // If no interface was specified, return the default address
     if (interface.empty()) {
+        return true;
+    }
+    // Explicit case for loopback.
+    if (interface == "lo") {
+        myaddr.sin_addr.s_addr = htonl( INADDR_LOOPBACK );
         return true;
     }
 


### PR DESCRIPTION
If --interface is used to restrict on what interface to listen, explicitly
listen also on loopback. This generally shouldn't be needed, because there
is the unix socket, but if the build runs in a chroot (e.g. with 'osc build'
from the openSUSE build service), then the unix socket is not reachable
and the client falls back to using the loopback.
The scheduler shouldn't need any such mechanism, daemons shouldn't use
loopback when talking to the scheduler.