### PR TITLE
Compile locally with coverage argument

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -434,6 +434,7 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                 seen_s = true;
             } else if (!strcmp(a, "-fprofile-arcs")
                        || !strcmp(a, "-ftest-coverage")
+                       || !strcmp(a, "--coverage")
                        || !strcmp(a, "-frepo")
                        || !strcmp(a, "-fprofile-generate")
                        || !strcmp(a, "-fprofile-use")


### PR DESCRIPTION
According
https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html
--coverage option is a synonym for -fprofile-arcs -ftest-coverage.