### PR TITLE
Add `--serialize-diagnostics` as argument with space

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -177,6 +177,7 @@ static bool is_argument_with_space(const char* argument)
         "-segs_read_only_addr",
         "-segs_read_write_addr",
         "-serialize-diagnostics",
+        "--serialize-diagnostics",
         "-std",
         "--stdlib",
         "--force-link",


### PR DESCRIPTION
Only `-serialize-diagnostics` is included in the arguments with space.  
But `--serialize-diagnostics` is also valid argument as [document](https://clang.llvm.org/docs/genindex.html) says.  
This issue make the icecc client set invalid file as input.

 
![image](https://user-images.githubusercontent.com/5088892/86450620-ca783700-bd54-11ea-94ba-c686f34daa36.png)
