### PR TITLE
Ignore -fdirectives-only and -frewrite-includes options

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -709,6 +709,12 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                 if (argv[i + 1]) {
                     args.append(argv[++i], Arg_Rest);
                 }
+            } else if (str_equal("-fdirectives-only", a)
+                       || str_equal("-frewrite-includes", a)) {
+                // These don't make sense to run locally, and we inject them where
+                // appropriate remotely if remote preprocessing is requested. Therefore,
+                // skip them if they were supplied.
+                ++i;
             } else {
                 args.append(a, Arg_Rest);
 


### PR DESCRIPTION
Icecream is already managing these flags remotely, and they don't make sense for purely local builds. Therefore, Icecream should ignore these flags when they are specified.

This change fixes #451.