### PR TITLE
icecc-create-env: add command line --addfile "path target" support

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -498,7 +498,9 @@ fi
 save_stripprefix="$stripprefix"
 stripprefix=
 for extrafile in $extrafiles; do
-    add_file $extrafile
+    target=$(echo $extrafile | cut -d= -f1)
+    path=$(echo $extrafile | cut -d= -f2)
+    add_file $path $target
 done
 stripprefix="$save_stripprefix"
 


### PR DESCRIPTION
This allows users to arbitrarily add files that they want to be remapped into some chroot location.

A specific use case is when wanting to remap /proc/cpuinfo from a custom cpuinfo with instantaneous cpu frequency data stripped out for the thinLTO support and the clang bug: https://bugs.llvm.org/show_bug.cgi?id=33008