### PR TITLE
fix daemon setting wrong memory limitation

### DIFF
--- a/daemon/load.cpp
+++ b/daemon/load.cpp
@@ -240,7 +240,7 @@ static unsigned long int scan_one(const char *buff, const char *key)
 }
 #endif
 
-static unsigned int calculateMemLoad(unsigned long int &NetMemFree)
+static unsigned int calculateMemLoad(unsigned long long &NetMemFree)
 {
     unsigned long long MemTotal = 0, MemFree = 0, Buffers = 0, Cached = 0;
 
@@ -272,6 +272,11 @@ static unsigned int calculateMemLoad(unsigned long int &NetMemFree)
         }
     }
 #endif
+    /* Bytes -> Kbytes */
+    MemFree /= 1024;
+    MemTotal /= 1024;
+    Buffers /= 1024;
+    Cached /= 1024;
 
 #elif defined( USE_SYSCTL )
     size_t len = sizeof(MemFree);
@@ -412,7 +417,7 @@ void fill_stats(unsigned long &myidleload, unsigned long &myniceload, unsigned i
     myniceload = load.niceLoad;
 
     if (msg) {
-        unsigned long int MemFree = 0;
+        unsigned long long MemFree = 0;
 
         memory_fillgrade = calculateMemLoad(MemFree);
 
@@ -428,6 +433,5 @@ void fill_stats(unsigned long &myidleload, unsigned long &myniceload, unsigned i
         msg->loadAvg10 = (load_t)(avg[2] * 1000);
 
         msg->freeMem = (load_t)(MemFree / 1024.0 + 0.5);
-
     }
 }


### PR DESCRIPTION
On macOS + clang environment, Clustering much more than 60 jobs makes kill my macOS (It even terminate my machine.)
I found that the daemon had been logging weird message about memory limitation.

```
[70527] 2020-09-29 09:28:11: Compile job memory limit set to 3459279 megabytes
[70496] 2020-09-29 18:28:11: handle connection returned 70529
[70496] 2020-09-29 18:28:11: request for job 52
```
That means the daemon set limitation to almost 34 terabytes.

I have found that the function `unsigned int culateMemLoad(...)` make free memory not in kilobytes but bytes.
In addition to that, the daemon limits max child counts into at most 4. But my machine has 20 children.

So this PR is trying to fix above two problems.