### PR TITLE
fix "call_cpp" could be executed more time than max_cpu

### DIFF
--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -270,7 +270,7 @@ static void check_for_failure(Msg *msg, MsgChannel *cserver)
 
 // 'unlock_sending' = dcc_lock_host() is held when this is called, temporarily yield the lock
 // while doing network transfers
-static void write_fd_to_server(int fd, MsgChannel *cserver, bool unlock_sending = false)
+static void write_fd_to_server(int fd, MsgChannel *cserver)
 {
     unsigned char buffer[100000]; // some random but huge number
     off_t offset = 0;
@@ -300,13 +300,6 @@ static void write_fd_to_server(int fd, MsgChannel *cserver, bool unlock_sending 
 
         if (!bytes || offset == sizeof(buffer)) {
             if (offset) {
-                // If write_fd_to_server() is called for sending preprocessed data,
-                // the dcc_lock_host() lock is held to limit the number cpp invocations
-                // to the cores available to prevent overload. But that would
-                // essentially also limit network transfers, so temporarily yield and
-                // reaquire again.
-                if(unlock_sending)
-                    dcc_unlock();
                 FileChunkMsg fcmsg(buffer, offset);
 
                 if (!cserver->send_msg(fcmsg)) {
@@ -323,15 +316,6 @@ static void write_fd_to_server(int fd, MsgChannel *cserver, bool unlock_sending 
                 uncompressed += fcmsg.len;
                 compressed += fcmsg.compressed;
                 offset = 0;
-                if(unlock_sending)
-                {
-                    if(!dcc_lock_host())
-                    {
-                        log_error() << "can't reaquire lock for local cpp" << endl;
-                        close(fd);
-                        throw client_error(32, "Error 32 - lock failed");
-                    }
-                }
             }
 
             if (!bytes) {
@@ -465,6 +449,11 @@ static int build_remote_int(CompileJob &job, UseCSMsg *usecs, MsgChannel *local_
 
             EnvTransferMsg msg(job.targetPlatform(), job.environmentVersion());
 
+            if (!dcc_lock_host()) {
+                log_error() << "can't lock for local cpp" << endl;
+                return EXIT_DISTCC_FAILED;
+            }
+
             if (!cserver->send_msg(msg)) {
                 throw client_error(6, "Error 6 - send environment to remote failed");
             }
@@ -481,6 +470,8 @@ static int build_remote_int(CompileJob &job, UseCSMsg *usecs, MsgChannel *local_
                 log_error() << "write of environment failed" << endl;
                 throw client_error(8, "Error 8 - write environment to remote failed");
             }
+
+            dcc_unlock();
 
             if (IS_PROTOCOL_31(cserver)) {
                 VerifyEnvMsg verifymsg(job.targetPlatform(), job.environmentVersion());
@@ -527,6 +518,11 @@ static int build_remote_int(CompileJob &job, UseCSMsg *usecs, MsgChannel *local_
             job.appendFlag( job.language() == CompileJob::Lang_OBJC ? "objective-c" : "objective-c++", Arg_Remote );
         }
 
+        if (!dcc_lock_host()) {
+            log_error() << "can't lock for local cpp" << endl;
+            return EXIT_DISTCC_FAILED;
+        }
+
         CompileFileMsg compile_file(&job);
         {
             log_block b("send compile_file");
@@ -546,10 +542,6 @@ static int build_remote_int(CompileJob &job, UseCSMsg *usecs, MsgChannel *local_
                 throw client_error(32, "Error 18 - (fork error?)");
             }
 
-            if (!dcc_lock_host()) {
-                log_error() << "can't lock for local cpp" << endl;
-                return EXIT_DISTCC_FAILED;
-            }
             HostUnlock hostUnlock; // automatic dcc_unlock()
 
             /* This will fork, and return the pid of the child.  It will not
@@ -563,7 +555,7 @@ static int build_remote_int(CompileJob &job, UseCSMsg *usecs, MsgChannel *local_
 
             try {
                 log_block bl2("write_fd_to_server from cpp");
-                write_fd_to_server(sockets[0], cserver, true /*yield lock*/);
+                write_fd_to_server(sockets[0], cserver);
             } catch (...) {
                 kill(cpp_pid, SIGTERM);
                 throw;
@@ -602,6 +594,8 @@ static int build_remote_int(CompileJob &job, UseCSMsg *usecs, MsgChannel *local_
             log_warning() << "write of end failed" << endl;
             throw client_error(12, "Error 12 - failed to send file to remote");
         }
+
+        dcc_unlock();
 
         Msg *msg;
         {


### PR DESCRIPTION
On macOS + clang environment, Clustering much more than 60+ jobs makes kill my macOS (It even terminate my machine.)
I have found "call_cpp" is executed much more time than machine's cpu core count.
I guess it might came from #527

### Environment
- 5 x (12 core mac mini) cluster
- macOS catalina

### Issue
My machine is forcefully terminated when 30 ~ 60 compile job just had distributed to cluster.

### Reason (I guess)
1. There're 60 clients totally. 12 icecc client have sent `CompileFileMsg` and got `dcc_lock_host` there's no remain lock now.
2. After very short time, they execute `call_cpp` and release the lock
https://github.com/icecc/icecream/blob/19680ed605f13a5c7b598587fcfcdfd9ac8022ec/client/remote.cpp#L290-L298
3. Another client can take the lock and execute 13th `call_cpp`
4. Eventually all 60 clients run `call_cpp` simultaneously as repeating step2 ~ step 3 very quickly.
5. Boom

I have moved some lock to other positions and checked that this PR solving the issue.
Now I'm using 80 clients for compiling my projects.
Thank you.