### PR TITLE
Update env of FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,12 +6,19 @@ task:
     CFLAGS: -I /usr/local/include
     CXXFLAGS: -I/usr/local/include
     LDFLAGS: -L/usr/local/lib
-  freebsd_instance:
-    matrix:
-      image: freebsd-12-1-release-amd64
+  compute_engine_instance:
+    image_project: freebsd-org-cloud-dev
+    platform: freebsd
+  matrix:
+    - name: 13.0-RELEASE
+      compute_engine_instance:
+        image: family/freebsd-13-0
+    - name: 12.2-RELEASE
+      compute_engine_instance:
+        image: family/freebsd-12-2
   install_script:
     - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
-    - pkg upgrade -y
+    - ASSUME_ALWAYS_YES=yes pkg bootstrap -f
     - pkg install -y autoconf automake asciidoc gmake libarchive libtool lzo2 pkgconf zstd
   script:
     - ./autogen.sh


### PR DESCRIPTION
- Ensure pkg bootstraped with the latest version
- Test in both 13.0 and 12.2
- Remove unnecessary `pkg upgrade` to spped up the build