### PR TITLE
Refactor pick_server and add new scheduler algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,12 @@ earth, when those users were isolated to their geographic location the speed
 improved for everyone. In most corporate environments within a single building
 everything works well, but between two buildings often is troublesome.
 
+If you plan to use Icecream in the cloud or anywhere else you would have more
+latency than a corporate LAN, you should strongly consider using a dedicated
+scheduler configured with one of the alternative scheduling algorithms. See[Some advice on configuration](#some-advice-on-configuration)
+for details on alternative scheduling algorithms. You should also consider
+using dedicated compile servers as well if at all practical.
+
 Some advice on configuration
 -----------------------------------------------------------------------------------------------------------------------------------
 
@@ -519,6 +525,28 @@ each side of the VPN you can save bandwidth. Netnames can be used to work around
 some limitations above: if a netname is set icecream schedulers and daemons will
 ignore the existence of other schedulers and daemons.
 
+Finally, you can configure the scheduler to use a different job scheduling
+algorithm to distribute the load across your compile servers. The default
+scheduling algorithm is "fastest"; however this may not actually be the
+fastest algorithm to complete a full build in the real world, so you
+should try multiple algorithms to find the best for your environment.
+
+Currently, you can choose from the following algorithms:
+* *random*: distribute jobs randomly across the network.
+* *round_robin*: schedule jobs on the host that has seen jobs least recently.
+  This scheduler tends to distribute job assignments evenly across the
+  network, but it may distribute actual load unevenly and works best for
+  homogeneous networks of dedicated compile servers.
+* *least_busy*: schedule jobs to the host with the highest percentage of
+  open job slots. This scheduler tends to distribute load evenly, but tasks may be
+  distributed unevenly and works best for heterogeneous networks of dedicated
+  compile servers.
+* *fastest*: schedule jobs on the host expected to complete it soonest. This
+  tends to favor using a few hosts in the network, though a portion of the
+  load will be allocated to new hosts and hosts that have not been used in
+  some time to build up statistics. This is the classic algorithm and is
+  suitable for relatively small and heterogeneous networks of compile
+  servers.
 
 Network setup for Icecream (firewalls)
 ---------------------------------------------------------------------------------------------------------------------------

--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -482,6 +482,9 @@ if test -n "$clang"; then
     search_addfile $orig_clang as /usr/bin
     search_addfile $orig_clang objcopy /usr/bin
 
+    # Make sure llvm-symbolizer is added if present so sanitized builds work.
+    search_addfile $orig_clang llvm-symbolizer /usr/bin
+
     # HACK: Clang4.0 and later access /proc/cpuinfo and report an error when they fail
     # to find it, even if they use a fallback mechanism, making the error useless
     # (at least in this case). Since the file is not really needed, create a fake one.

--- a/doc/icecc-scheduler.adoc
+++ b/doc/icecc-scheduler.adoc
@@ -26,6 +26,11 @@ monitors.
 Options
 -------
 
+*-a, --algorithm* _algorithm-name_::
+    The job scheduling algorithm to use. Choose from:
+    _random_, _round_robin_, _least_busy_, _fastest_.
+    Defaults to _fastest_.
+
 *-d, --daemonize*::
     Detach daemon from shell.
 

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -871,7 +871,7 @@ static CompileServer *pick_server_fastest(Job *job, list<CompileServer *> &eligi
     return bestpre;
 }
 
-static CompileServer *pick_server(Job *job, SchedulerAlgorithmName scheduler_algorithm)
+static CompileServer *pick_server(Job *job, SchedulerAlgorithmName schedulerAlgorithm)
 {
 #if DEBUG_SCHEDULER > 0
     /* consistency checking for now */
@@ -928,18 +928,18 @@ static CompileServer *pick_server(Job *job, SchedulerAlgorithmName scheduler_alg
             << " load: "
             << selected->load()
             << " can install: "
-            << selected->can_install(job)
+            << selected->can_install(job);
         return selected;
     }
 
     CompileServer *selected;
-    switch (scheduler_algorithm) {
+    switch (schedulerAlgorithm) {
         case SchedulerAlgorithmName::NONE:
         case SchedulerAlgorithmName::UNDEFINED:
             [[fallthrough]];
         default:
             trace()
-                << "unknown scheduler_algorithm " << scheduler_algorithm
+                << "unknown scheduler algorithm " << schedulerAlgorithm
                 << ", using " << SchedulerAlgorithmName::RANDOM << endl;
             [[fallthrough]];
         case SchedulerAlgorithmName::RANDOM:
@@ -959,11 +959,11 @@ static CompileServer *pick_server(Job *job, SchedulerAlgorithmName scheduler_alg
     if (selected) {
         trace()
             << "selected " << selected->nodeName()
-            << " using " << scheduler_algorithm << " algorithm" << endl;
+            << " using " << schedulerAlgorithm << " algorithm" << endl;
     } else {
         trace()
             << "failed to select a server using "
-            << scheduler_algorithm << " algorithm" << endl;
+            << schedulerAlgorithm << " algorithm" << endl;
     }
     return selected;
 }
@@ -1054,7 +1054,7 @@ static time_t prune_servers()
     return min_time;
 }
 
-static bool empty_queue(SchedulerAlgorithmName scheduler)
+static bool empty_queue(SchedulerAlgorithmName schedulerAlgorithm)
 {
     JobRequestPosition jobPosition = get_first_job_request();
     if (!jobPosition.isValid()) {
@@ -1067,7 +1067,7 @@ static bool empty_queue(SchedulerAlgorithmName scheduler)
     Job* job = jobPosition.job;
 
     while (true) {
-        use_cs = pick_server(job, scheduler);
+        use_cs = pick_server(job, schedulerAlgorithm);
 
         if (use_cs) {
             break;

--- a/scheduler/scheduler.h
+++ b/scheduler/scheduler.h
@@ -27,4 +27,68 @@
 // Values 0 to 3.
 #define DEBUG_SCHEDULER 0
 
+// The weight the "fastest" scheduler places on using a
+// server with recent statistics over one that has not
+// been used for a while. Values 0 - 128, with higher
+// values meaning the "fastest" servers are used more
+// often.
+#define STATS_UPDATE_WEIGHT 120
+
+#include <iostream>
+#include <string>
+
+#include "../services/job.h"
+#include "compileserver.h"
+
+
+class SchedulerAlgorithmName {
+public:
+    enum Value: uint8_t {
+        NONE=0,
+        RANDOM,
+        ROUND_ROBIN,
+        LEAST_BUSY,
+        FASTEST,
+        UNDEFINED=255
+    };
+
+    SchedulerAlgorithmName() = default;
+    constexpr SchedulerAlgorithmName(Value name)
+        : name_{name}
+    {}
+
+    constexpr operator Value() const { return name_; }
+    explicit operator bool() = delete;
+
+    std::basic_string<char> to_string() const {
+        switch (name_) {
+            case SchedulerAlgorithmName::NONE:
+                return "NONE";
+            case SchedulerAlgorithmName::RANDOM:
+                return "RANDOM";
+            case SchedulerAlgorithmName::ROUND_ROBIN:
+                return "ROUND_ROBIN";
+            case SchedulerAlgorithmName::LEAST_BUSY:
+                return "LEAST_BUSY";
+            case SchedulerAlgorithmName::FASTEST:
+                return "FASTEST";
+            case SchedulerAlgorithmName::UNDEFINED:
+                return "UNDEFINED";
+        }
+        return nullptr;
+    }
+
+private:
+    Value name_;
+};
+
+inline std::basic_string<char> operator+=(std::basic_string<char> left, const SchedulerAlgorithmName &right) {
+    return left.append(right.to_string());
+}
+
+inline std::ostream& operator<<(std::ostream &os, const SchedulerAlgorithmName &name) {
+    os << name.to_string();
+    return os;
+}
+
 #endif

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -2,5 +2,5 @@
 
 void f()
     {
-    int unused; // this should give a warning about being unused
+    int unused;
     }

--- a/tests/messages.h
+++ b/tests/messages.h
@@ -3,7 +3,7 @@
 
 void g()
     {
-    int unused; // this should also give a warning about being unused
+    int unused;
     }
 
 #endif


### PR DESCRIPTION
The classic Icecream scheduler doesn't work well in all environments, especially when deployed into the cloud. To remedy that, `pick_server` is refactored, and several new scheduling algorithms are added as options:
  * random
  * round_robin
  * least_busy
  * fastest

The `fastest` algorithm is the "classic" algorithm.

I've also fixed up a few parts of the `fastest` algorithm and server selection in general to be a bit more obvious in their function. In particular, the original weight assumed that there were at least 1000 nodes in the cluster. This has been changed to scale along with the size of the cluster.