### PR TITLE
Add llvm-symbolizer to environment tarball

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -482,6 +482,9 @@ if test -n "$clang"; then
     search_addfile $orig_clang as /usr/bin
     search_addfile $orig_clang objcopy /usr/bin
 
+    # Make sure llvm-symbolizer is added if present so sanitized builds work.
+    search_addfile $orig_clang llvm-symbolizer /usr/bin
+
     # HACK: Clang4.0 and later access /proc/cpuinfo and report an error when they fail
     # to find it, even if they use a fallback mechanism, making the error useless
     # (at least in this case). Since the file is not really needed, create a fake one.


### PR DESCRIPTION
We weren't adding `llvm-symbolizer` to the environment tarball even though we assume it is present in the tests. It really should be put in there when available, or sanitizer output coming from a remote job will be hard to decipher.