### PR TITLE
Add missing libarchive include path to daemon/Makefile.am

### DIFF
--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -15,7 +15,8 @@ iceccd_LDADD = \
 	$(LIBARCHIVE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir)/services
+	-I$(top_srcdir)/services \
+	$(LIBARCHIVE_CFLAGS)
 
 AM_LIBTOOLFLAGS = --silent
 


### PR DESCRIPTION
At least on MacOS it was impossible to build daemon binary because of missing include directory to libarchive headers.