### PR TITLE
Refactor the `Msg` class

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,12 +10,12 @@ task:
     image_project: freebsd-org-cloud-dev
     platform: freebsd
   matrix:
-    - name: 13.0-RELEASE
+    - name: 13.1-RELEASE
       compute_engine_instance:
-        image: family/freebsd-13-0
-    - name: 12.2-RELEASE
+        image: family/freebsd-13-1
+    - name: 12.3-RELEASE
       compute_engine_instance:
-        image: family/freebsd-12-2
+        image: family/freebsd-12-3
   install_script:
     - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
     - ASSUME_ALWAYS_YES=yes pkg bootstrap -f

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ tests/testargs.log
 tests/testargs.trs
 tests/test-setup.sh
 tests/listing.txt
+unittests/testargs
+unittests/testargs.trs
 # others
 compile_commands.json
 .vs*

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -496,7 +496,7 @@ int main(int argc, char **argv)
 
             string native;
 
-            if (umsg && umsg->type == M_NATIVE_ENV) {
+            if (umsg && *umsg == Msg::NATIVE_ENV) {
                 native = static_cast<UseNativeEnvMsg*>(umsg)->nativeVersion;
             }
 
@@ -600,7 +600,7 @@ int main(int argc, char **argv)
 
         /* If we can't talk to the daemon anymore we need to fall back
            to lock file locking.  */
-        if (!startme || startme->type != M_JOB_LOCAL_BEGIN) {
+        if (!startme || *startme != Msg::JOB_LOCAL_BEGIN) {
             delete startme;
             delete local_daemon;
             return build_local(job, nullptr);

--- a/daemon/environment.cpp
+++ b/daemon/environment.cpp
@@ -418,7 +418,7 @@ pid_t start_install_environment(const std::string &basename, const std::string &
     string dirname = basename + "/target=" + target;
     Msg *msg = c->get_msg(30);
 
-    if (!msg || msg->type != M_FILE_CHUNK) {
+    if (!msg || *msg != Msg::FILE_CHUNK) {
         trace() << "Expected first file chunk\n";
         return 0;
     }

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -1091,13 +1091,13 @@ bool Daemon::handle_file_chunk_env(Client *client, Msg *msg)
        the file chunk to the child, but we can't let the child
        handle MsgChannel itself due to MsgChannel's stupid
        caching layer inbetween, which causes us to lose partial
-       data after the M_END msg of the env transfer.  */
+       data after the END msg of the env transfer.  */
 
     assert(client);
     assert(client->status == Client::TOINSTALL || client->status == Client::WAITINSTALL);
     assert(client->pipe_to_child >= 0);
 
-    if (msg->type == M_FILE_CHUNK) {
+    if (*msg == Msg::FILE_CHUNK) {
         FileChunkMsg *fcmsg = static_cast<FileChunkMsg *>(msg);
         ssize_t len = fcmsg->len;
         off_t off = 0;
@@ -1129,7 +1129,7 @@ bool Daemon::handle_file_chunk_env(Client *client, Msg *msg)
         return true;
     }
 
-    if (msg->type == M_END) {
+    if (*msg == Msg::END) {
         trace() << "received end of environment, waiting for child" << endl;
         close(client->pipe_to_child);
         client->pipe_to_child = -1;
@@ -1143,7 +1143,7 @@ bool Daemon::handle_file_chunk_env(Client *client, Msg *msg)
     }
 
     // unexpected message type
-    log_error() << "protocol error while receiving environment (" << msg->type << ")" << endl;
+    log_error() << "protocol error while receiving environment (" << msg->to_string() << ")" << endl;
     handle_end(client, 138);
     return false;
 }
@@ -1176,7 +1176,7 @@ bool Daemon::handle_env_install_child_done(Client *client)
     if( !success )
         return finish_transfer_env( client, true ); // cancel
     if( client->pipe_to_child >= 0 ) {
-        // we still haven't received M_END message, wait for that
+        // we still haven't received END message, wait for that
         assert( client->status == Client::TOINSTALL );
         return true;
     }
@@ -1896,37 +1896,37 @@ bool Daemon::handle_activity(Client *client)
         return ret;
     }
 
-    switch (msg->type) {
-    case M_GET_NATIVE_ENV:
+    switch (*msg) {
+    case Msg::GET_NATIVE_ENV:
         ret = handle_get_native_env(client, dynamic_cast<GetNativeEnvMsg *>(msg));
         break;
-    case M_COMPILE_FILE:
+    case Msg::COMPILE_FILE:
         ret = handle_compile_file(client, msg);
         break;
-    case M_TRANFER_ENV:
+    case Msg::TRANFER_ENV:
         ret = handle_transfer_env(client, dynamic_cast<EnvTransferMsg*>(msg));
         break;
-    case M_GET_CS:
+    case Msg::GET_CS:
         ret = handle_get_cs(client, msg);
         break;
-    case M_END:
+    case Msg::END:
         handle_end(client, 119);
         ret = false;
         break;
-    case M_JOB_LOCAL_BEGIN:
+    case Msg::JOB_LOCAL_BEGIN:
         ret = handle_local_job(client, msg);
         break;
-    case M_JOB_DONE:
+    case Msg::JOB_DONE:
         ret = handle_job_done(client, dynamic_cast<JobDoneMsg *>(msg));
         break;
-    case M_VERIFY_ENV:
+    case Msg::VERIFY_ENV:
         ret = handle_verify_env(client, dynamic_cast<VerifyEnvMsg *>(msg));
         break;
-    case M_BLACKLIST_HOST_ENV:
+    case Msg::BLACKLIST_HOST_ENV:
         ret = handle_blacklist_host_env(client, msg);
         break;
     default:
-        log_error() << "protocol error " << msg->type << " on client "
+        log_error() << "protocol error " << msg->to_string() << " on client "
                     << client->dump() << endl;
         client->channel->send_msg(EndMsg());
         handle_end(client, 120);
@@ -2065,28 +2065,28 @@ void Daemon::answer_client_requests()
 
                 ret = 0;
 
-                switch (msg->type) {
-                case M_PING:
+                switch (*msg) {
+                case Msg::PING:
 
                     if (!IS_PROTOCOL_27(scheduler)) {
                         ret = !send_scheduler(PingMsg());
                     }
 
                     break;
-                case M_USE_CS:
+                case Msg::USE_CS:
                     ret = scheduler_use_cs(static_cast<UseCSMsg *>(msg));
                     break;
-                case M_NO_CS:
+                case Msg::NO_CS:
                     ret = scheduler_no_cs(static_cast<NoCSMsg *>(msg));
                     break;
-                case M_GET_INTERNALS:
+                case Msg::GET_INTERNALS:
                     ret = scheduler_get_internals();
                     break;
-                case M_CS_CONF:
+                case Msg::CS_CONF:
                     ret = handle_cs_conf(static_cast<ConfCSMsg *>(msg));
                     break;
                 default:
-                    log_error() << "unknown scheduler type " << (char)msg->type << endl;
+                    log_error() << "unknown scheduler type " << msg->to_string() << endl;
                     ret = 1;
                 }
 

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -449,7 +449,7 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
                     fcmsg = nullptr;
                     delete msg;
                 } else {
-                    if (msg->type == M_END) {
+                    if (*msg == Msg::END) {
                         input_complete = true;
 
                         if (!fcmsg && sock_in[1] != -1) {
@@ -460,7 +460,7 @@ int work_it(CompileJob &j, unsigned int job_stat[], MsgChannel *client, CompileR
                         }
 
                         delete msg;
-                    } else if (msg->type == M_FILE_CHUNK) {
+                    } else if (*msg == Msg::FILE_CHUNK) {
                         fcmsg = static_cast<FileChunkMsg*>(msg);
                         off = 0;
 

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -1722,7 +1722,7 @@ static bool handle_line(CompileServer *cs, Msg *_m)
                 msg = it->get_msg();
             }
 
-            if (msg && msg->type == M_STATUS_TEXT) {
+            if (msg && *msg == Msg::STATUS_TEXT) {
                 if (!cs->send_msg(TextMsg(dynamic_cast<StatusTextMsg *>(msg)->text))) {
                     return false;
                 }
@@ -1757,17 +1757,17 @@ static bool try_login(CompileServer *cs, Msg *m)
 {
     bool ret = true;
 
-    switch (m->type) {
-    case M_LOGIN:
+    switch (*m) {
+    case Msg::LOGIN:
         cs->setType(CompileServer::DAEMON);
         ret = handle_login(cs, m);
         break;
-    case M_MON_LOGIN:
+    case Msg::MON_LOGIN:
         cs->setType(CompileServer::MONITOR);
         ret = handle_mon_login(cs, m);
         break;
     default:
-        log_info() << "Invalid first message " << (char)m->type << endl;
+        log_info() << "Invalid first message " << m->to_string() << endl;
         ret = false;
         break;
     }
@@ -1898,43 +1898,43 @@ static bool handle_activity(CompileServer *cs)
         return try_login(cs, m);
     }
 
-    switch (m->type) {
-    case M_JOB_BEGIN:
+    switch (*m) {
+    case Msg::JOB_BEGIN:
         ret = handle_job_begin(cs, m);
         break;
-    case M_JOB_DONE:
+    case Msg::JOB_DONE:
         ret = handle_job_done(cs, m);
         break;
-    case M_PING:
+    case Msg::PING:
         ret = handle_ping(cs, m);
         break;
-    case M_STATS:
+    case Msg::STATS:
         ret = handle_stats(cs, m);
         break;
-    case M_END:
+    case Msg::END:
         handle_end(cs, m);
         ret = false;
         break;
-    case M_JOB_LOCAL_BEGIN:
+    case Msg::JOB_LOCAL_BEGIN:
         ret = handle_local_job(cs, m);
         break;
-    case M_JOB_LOCAL_DONE:
+    case Msg::JOB_LOCAL_DONE:
         ret = handle_local_job_done(cs, m);
         break;
-    case M_LOGIN:
+    case Msg::LOGIN:
         ret = handle_relogin(cs, m);
         break;
-    case M_TEXT:
+    case Msg::TEXT:
         ret = handle_line(cs, m);
         break;
-    case M_GET_CS:
+    case Msg::GET_CS:
         ret = handle_cs_request(cs, m);
         break;
-    case M_BLACKLIST_HOST_ENV:
+    case Msg::BLACKLIST_HOST_ENV:
         ret = handle_blacklist_host_env(cs, m);
         break;
     default:
-        log_info() << "Invalid message type arrived " << (char)m->type << endl;
+        log_info() << "Invalid message type arrived " << m->to_string() << endl;
         handle_end(cs, m);
         ret = false;
         break;


### PR DESCRIPTION
This is a refactor of the `Msg` class that gets rid of the need for `MsgType`, which was a separate, non-scoped `enum`. Having the non-scoped `enum` around meant we had bare identifiers everywhere. I'm using an "enhanced `enum`" here (the kind we used for  `SchedulerAlgorithmName`) to do the refactor.

The benefits of the refactor are that we no longer need a separate variable to hold the `enum` value anymore because we can just use the object itself, and as a result it's a lot easier to output the actual name of the message in logs. In addition, having a scoped `enum` means the object is more self-container, and it will be easier to do other refactors.