### PR TITLE
Fix the monitor GetCS and JobDone messages not having proper type

### DIFF
--- a/services/comm.h
+++ b/services/comm.h
@@ -210,7 +210,7 @@ public:
     virtual void fill_from_channel(MsgChannel *c);
     virtual void send_to_channel(MsgChannel *c) const;
 
-private:
+protected:
     Value value_;
 };
 
@@ -879,6 +879,7 @@ public:
     MonGetCSMsg()
         : GetCSMsg()
     { // overwrite
+        value_ = MON_GET_CS;
         clientid = job_id = 0;
     }
 
@@ -886,7 +887,9 @@ public:
         : GetCSMsg(Environments(), m->filename, m->lang, 1, m->target, 0, std::string(), false, m->client_count, m->niceness)
         , job_id(jobid)
         , clientid(hostid)
-    {}
+    {
+        value_ = MON_GET_CS;
+    }
 
     virtual void fill_from_channel(MsgChannel *c);
     virtual void send_to_channel(MsgChannel *c) const;
@@ -923,11 +926,15 @@ class MonJobDoneMsg : public JobDoneMsg
 public:
     MonJobDoneMsg()
         : JobDoneMsg()
-    {}
+    {
+        value_ = MON_JOB_DONE;
+    }
 
     MonJobDoneMsg(const JobDoneMsg &o)
         : JobDoneMsg(o)
-    {}
+    {
+        value_ = MON_JOB_DONE;
+    }
 };
 
 class MonLocalJobBeginMsg : public Msg


### PR DESCRIPTION
Broken by the refactor at c0f9d537bd47e3326e1126444267cf43bd59696f