### PR TITLE
Fix relative paths to daemon's -b env

### DIFF
--- a/client/util.cpp
+++ b/client/util.cpp
@@ -354,18 +354,3 @@ int resolve_link(const std::string &file, std::string &resolved)
     resolved = std::string(buf);
     return 0;
 }
-
-std::string get_cwd()
-{
-    static std::vector<char> buffer(1024);
-
-    errno = 0;
-    while (getcwd(&buffer[0], buffer.size() - 1) == nullptr && errno == ERANGE) {
-        buffer.resize(buffer.size() + 1024);
-        errno = 0;
-    }
-    if (errno != 0)
-        return std::string();
-
-    return string(&buffer[0]);
-}

--- a/client/util.h
+++ b/client/util.h
@@ -39,7 +39,6 @@ extern bool compiler_has_color_output(const CompileJob &job);
 extern bool output_needs_workaround(const CompileJob &job);
 extern bool ignore_unverified();
 extern int resolve_link(const std::string &file, std::string &resolved);
-extern std::string get_cwd();
 
 extern bool dcc_lock_host();
 extern void dcc_unlock();

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -2429,6 +2429,9 @@ int main(int argc, char **argv)
 
             if (optarg && *optarg) {
                 d.envbasedir = optarg;
+                if (!is_path_absolute(d.envbasedir)) {
+                    d.envbasedir = get_cwd() + "/" + d.envbasedir;
+                }
             }
 
             break;

--- a/services/util.cpp
+++ b/services/util.cpp
@@ -61,6 +61,26 @@ string find_prefix(const string &basename)
     return basename.substr(0, index);
 }
 
+std::string get_cwd()
+{
+    static std::vector<char> buffer(1024);
+
+    errno = 0;
+    while (getcwd(&buffer[0], buffer.size() - 1) == nullptr && errno == ERANGE) {
+        buffer.resize(buffer.size() + 1024);
+        errno = 0;
+    }
+    if (errno != 0)
+        return std::string();
+
+    return string(&buffer[0]);
+}
+
+bool is_path_absolute(const std::string &path)
+{
+    return !path.empty() && path[0] == '/';
+}
+
 /*
  We support these compilers:
  - cc/c++

--- a/services/util.h
+++ b/services/util.h
@@ -28,6 +28,8 @@
 
 extern std::string find_basename(const std::string &sfile);
 extern std::string find_prefix(const std::string &basename);
+extern std::string get_cwd();
+extern bool is_path_absolute(const std::string &path);
 // These two detect if the given binary is a C/C++ compiler based on its name(gcc->C,clang++->C++)
 extern bool is_c_compiler(const std::string& compiler);
 extern bool is_cpp_compiler(const std::string& compiler);


### PR DESCRIPTION
Because the daemon chdirs to /, the envbasedir path would be relative to /. To mitigate that, resolve the relative envbasedir path against the current working directory before this directory is chdired.