### PR TITLE
avoid integer overflow for cache-limit

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -2349,7 +2349,7 @@ int main(int argc, char **argv)
                     int mb = atoi(optarg);
 
                     if (!errno) {
-                        cache_size_limit = mb * 1024 * 1024;
+                        cache_size_limit = mb * 1024L * 1024;
                     }
                 } else {
                     usage("Error: --cache-limit requires argument");


### PR DESCRIPTION
Without this, "mb * 1024 * 1024" overflows for mb >= 2048. The result is then cast into size_t, which is unsigned and usually a 64-bit integer. The end result is, that the cache is now basically unlimited.

Fix this by making mb a size_t as well to avoid the overflow.