### PR TITLE
Remove link to lgtm.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![Build Status (Linux & macOS)](https://travis-ci.org/icecc/icecream.svg?branch=master)](https://travis-ci.org/icecc/icecream)
 [![Build Status (FreeBSD)](https://api.cirrus-ci.com/github/icecc/icecream.svg)](https://cirrus-ci.com/github/icecc/icecream)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d0fd9ba53b424b37964340970392eec2)](https://www.codacy.com/app/icecc/icecream?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=icecc/icecream&amp;utm_campaign=Badge_Grade)
-[![Code Quality: Cpp](https://img.shields.io/lgtm/grade/cpp/g/icecc/icecream.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/icecc/icecream/context:cpp)
-[![Total Alerts](https://img.shields.io/lgtm/alerts/g/icecc/icecream.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/icecc/icecream/alerts)
 
 [Icecream](Icecream) was created by SUSE based on distcc. Like distcc,
 [Icecream](Icecream) takes compile jobs from a build and


### PR DESCRIPTION
lgtm.com is now part of Github code scanning.

The following quote is taken from [The next step for LGTM.com: GitHub code scanning!](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/).

> Three years ago, the team that built LGTM.com joined GitHub. From that moment
> on, we have worked tirelessly to natively integrate its underlying CodeQL
> analysis technology into GitHub. In 2020, GitHub code scanning was launched in
> public beta, and later that year it became generally available for everyone.
> GitHub code scanning is powered by the very same analysis engine: CodeQL.

> We’ve since continued to invest in CodeQL and GitHub code scanning. Today,
> GitHub code scanning has all of LGTM.com’s key features—and more! The time has
> therefore come to announce the plan for the gradual deprecation of LGTM.com.