### PR TITLE
fix str_startswith

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -52,7 +52,7 @@ inline bool str_equal(const char* a, const char* b)
 
 inline int str_startswith(const char *head, const char *worm)
 {
-    return !strncmp(head, worm, strlen(head));
+    return !strncmp(head, worm, strlen(worm));
 }
 
 /* Some files should always be built locally... */


### PR DESCRIPTION
in case len of head is less than worm, it should not match.

This causes compiler like `gcc -foo -bar -s` to be interpreted as `gcc -foo -bar -somethingelse`, and due to -s icecc thinks that it is starting with -save-temps= causing to locally compile