### PR TITLE
compare client arg "save-temp" argument properly

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -440,8 +440,8 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                        || !strcmp(a, "-fprofile-use")
                        || !strcmp(a, "-save-temps")
                        || !strcmp(a, "--save-temps")
-                       || str_startswith(a, "-save-temps=")
-                       || str_startswith(a, "--save-temps=")
+                       || str_startswith("-save-temps=", a)
+                       || str_startswith("--save-temps=", a)
                        || !strcmp(a, "-fbranch-probabilities")) {
                 log_warning() << "compiler will emit additional local files (argument " << a << "); building locally" << endl;
                 always_local = true;


### PR DESCRIPTION
otherwise -s (strip) flag will be picked up as "save-temp" and will cause local build

example:
```

ICECC[2817] 2024-05-01 22:38:03: invoked as: /usr/lib/icecream/bin/c++ -DCMS_NO_REGISTER_KEYWORD=1 -DFFMPEG_VER_SHA=6.0.1 -DFMT_SHARED -DHAS_AIRPLAY=1 -DHAS_AIRTUNES=1 -DHAS_ALSA=1 -DHAS_AVAHI=1 -DHAS_DBUS=1 -DHAS_EGL=1 -DHAS_FILESYSTEM_NFS -DHAS_GBM_BO_MAP=1 -DHAS_GBM_MODIFIERS=1 -DHAS_GLES=3 -DHAS_LIRC=1 -DHAS_MYSQL=1 -DHAS_NEON -DHAS_NFS_MOUNT_GETEXPORTS_TIMEOUT -DHAS_NFS_SET_TIMEOUT -DHAS_PULSEAUDIO=1 -DHAS_UDFREAD=1 -DHAS_ZEROCONF=1 -DHAVE_DRM_MODIFIER_NAME=1 -DHAVE_EGLEXTANGLE=1 -DHAVE_GBM=1 -DHAVE_HDR_OUTPUT_METADATA=1 -DHAVE_LCMS2=1 -DHAVE_LIBBLUETOOTH=1 -DHAVE_LIBCAP=1 -DHAVE_LIBCEC=1 -DHAVE_LIBUDEV=1 -DHAVE_LIBXRANDR=1 -DHAVE_LIBXSLT=1 -DHAVE_NEW_CROSSGUID -DHAVE_X11=1 -DSPDLOG_COMPILED_LIB -DSPDLOG_DEBUG_ON -DSPDLOG_FMT_EXTERNAL -DSPDLOG_NO_ATOMIC_LEVELS -DTINYXML2_IMPORT -D_FILE_OFFSET_BITS=64 -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/kodi-build -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/lib -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc/platform/linux -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc/cores/VideoPlayer -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/kodi-build/build -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc/platform/posix -isystem /home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/kodi-build/build/include -isystem /usr/include/python3.11 -isystem /usr/include/samba-4.0 -isystem /usr/include/fribidi -isystem /home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc/contrib -isystem /usr/include/lzo -isystem /usr/include/dbus-1.0 -isystem /usr/lib/dbus-1.0/include -isystem /usr/include/libxml2 -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/sysprof-6 -isystem /usr/include/freetype2 -isystem /usr/include/libpng16 -isystem /usr/include/harfbuzz -isystem /home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/kodi-build/build/cores/RetroPlayer/messages -isystem /usr/include/libdrm -march=armv8-a -O2 -pipe -fstack-protector-strong -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -Wno-error=restrict -g3 -Wall -Wdouble-promotion -Wmissing-field-initializers -Wsign-compare -Wextra -Wno-unused-parameter -Wnon-virtual-dtor -O3 -DNDEBUG -s -std=c++17 -flto=8 -fno-fat-lto-objects -DTARGET_POSIX -DTARGET_LINUX -D_GNU_SOURCE -DHAVE_LINUX_UDMABUF=1 -DHAVE_LINUX_DMA_HEAP=1 -DHAVE_LINUX_DMA_BUF=1 -DHAVE_MKOSTEMP=1 -DHAVE_LINUX_MEMFD=1 -DHAVE_STATX=1 -D__STDC_CONSTANT_MACROS -D_FILE_OFFSET_BITS=64 -DHAS_POSIX_NETWORK -DHAS_LINUX_NETWORK -DHAS_BUILTIN_SYNC_ADD_AND_FETCH=1 -DHAS_BUILTIN_SYNC_SUB_AND_FETCH=1 -DHAS_BUILTIN_SYNC_VAL_COMPARE_AND_SWAP=1 -DHAVE_INOTIFY=1 -DHAVE_POSIX_FADVISE=1 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DHAVE_INTTYPES_H=1 -DHAVE_LIBBLURAY=1 -DHAVE_LIBBLURAY_BDJ=1 -DHAS_ISO9660PP=1 -DHAS_WEB_SERVER=1 -DHAS_WEB_INTERFACE=1 -DHAS_PYTHON=1 -DHAS_FILESYSTEM_SMB=1 -DHAVE_LIBVA=1 -DHAVE_WAYLAND=1 -DHAS_UPNP=1 -DHAS_OPTICAL_DRIVE -DHAS_CDDA_RIPPER -DBIN_INSTALL_PATH="/usr/lib/kodi" -DINSTALL_PATH="/usr/share/kodi" -Werror=double-promotion -Werror=missing-field-initializers -Werror=sign-compare -pthread -MD -MT build/games/controllers/guicontrols/CMakeFiles/games_controller_guicontrols.dir/GUIFeatureFactory.cpp.o -MF CMakeFiles/games_controller_guicontrols.dir/GUIFeatureFactory.cpp.o.d -o CMakeFiles/games_controller_guicontrols.dir/GUIFeatureFactory.cpp.o -c /home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc/games/controllers/guicontrols/GUIFeatureFactory.cpp


ICECC[2817] 2024-05-01 22:38:03: connected to /var/run/icecc/iceccd.socket
ICECC[2817] 2024-05-01 22:38:03: compiler will emit additional local files (argument -s); building locally
ICECC[2817] 2024-05-01 22:38:03: <building_local>
ICECC[2550] 2024-05-01 22:38:03: </building_local: 26274ms>



ICECC[2663] 2024-05-01 22:38:03: invoking: /usr/sbin/c++ -DCMS_NO_REGISTER_KEYWORD=1 -DFFMPEG_VER_SHA=6.0.1 -DFMT_SHARED -DHAS_AIRPLAY=1 -DHAS_AIRTUNES=1 -DHAS_ALSA=1 -DHAS_AVAHI=1 -DHAS_DBUS=1 -DHAS_EGL=1 -DHAS_FILESYSTEM_NFS -DHAS_GBM_BO_MAP=1 -DHAS_GBM_MODIFIERS=1 -DHAS_GLES=3 -DHAS_LIRC=1 -DHAS_MYSQL=1 -DHAS_NEON -DHAS_NFS_MOUNT_GETEXPORTS_TIMEOUT -DHAS_NFS_SET_TIMEOUT -DHAS_PULSEAUDIO=1 -DHAS_UDFREAD=1 -DHAS_ZEROCONF=1 -DHAVE_DRM_MODIFIER_NAME=1 -DHAVE_EGLEXTANGLE=1 -DHAVE_GBM=1 -DHAVE_HDR_OUTPUT_METADATA=1 -DHAVE_LCMS2=1 -DHAVE_LIBBLUETOOTH=1 -DHAVE_LIBCAP=1 -DHAVE_LIBCEC=1 -DHAVE_LIBUDEV=1 -DHAVE_LIBXRANDR=1 -DHAVE_LIBXSLT=1 -DHAVE_NEW_CROSSGUID -DHAVE_X11=1 -DSPDLOG_COMPILED_LIB -DSPDLOG_DEBUG_ON -DSPDLOG_FMT_EXTERNAL -DSPDLOG_NO_ATOMIC_LEVELS -DTINYXML2_IMPORT -D_FILE_OFFSET_BITS=64 -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/kodi-build -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/lib -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc/platform/linux -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc/cores/VideoPlayer -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/kodi-build/build -I/home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc/platform/posix -isystem /home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/kodi-build/build/include -isystem /usr/include/python3.11 -isystem /usr/include/samba-4.0 -isystem /usr/include/fribidi -isystem /home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc/contrib -isystem /usr/include/lzo -isystem /usr/include/dbus-1.0 -isystem /usr/lib/dbus-1.0/include -isystem /usr/include/libxml2 -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/sysprof-6 -isystem /usr/include/freetype2 -isystem /usr/include/libpng16 -isystem /usr/include/harfbuzz -isystem /home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/kodi-build/build/cores/RetroPlayer/messages -isystem /usr/include/libdrm -march=armv8-a -O2 -pipe -fstack-protector-strong -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -Wno-error=restrict -g3 -Wall -Wdouble-promotion -Wmissing-field-initializers -Wsign-compare -Wextra -Wno-unused-parameter -Wnon-virtual-dtor -O3 -DNDEBUG -s -std=c++17 -flto=8 -fno-fat-lto-objects -DTARGET_POSIX -DTARGET_LINUX -D_GNU_SOURCE -DHAVE_LINUX_UDMABUF=1 -DHAVE_LINUX_DMA_HEAP=1 -DHAVE_LINUX_DMA_BUF=1 -DHAVE_MKOSTEMP=1 -DHAVE_LINUX_MEMFD=1 -DHAVE_STATX=1 -D__STDC_CONSTANT_MACROS -D_FILE_OFFSET_BITS=64 -DHAS_POSIX_NETWORK -DHAS_LINUX_NETWORK -DHAS_BUILTIN_SYNC_ADD_AND_FETCH=1 -DHAS_BUILTIN_SYNC_SUB_AND_FETCH=1 -DHAS_BUILTIN_SYNC_VAL_COMPARE_AND_SWAP=1 -DHAVE_INOTIFY=1 -DHAVE_POSIX_FADVISE=1 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DHAVE_INTTYPES_H=1 -DHAVE_LIBBLURAY=1 -DHAVE_LIBBLURAY_BDJ=1 -DHAS_ISO9660PP=1 -DHAS_WEB_SERVER=1 -DHAS_WEB_INTERFACE=1 -DHAS_PYTHON=1 -DHAS_FILESYSTEM_SMB=1 -DHAVE_LIBVA=1 -DHAVE_WAYLAND=1 -DHAS_UPNP=1 -DHAS_OPTICAL_DRIVE -DHAS_CDDA_RIPPER -DBIN_INSTALL_PATH="/usr/lib/kodi" -DINSTALL_PATH="/usr/share/kodi" -Werror=double-promotion -Werror=missing-field-initializers -Werror=sign-compare -pthread -MD -MT build/games/addons/input/CMakeFiles/gameinput.dir/GameClientTopology.cpp.o -MF CMakeFiles/gameinput.dir/GameClientTopology.cpp.o.d /home/alarm/.agr/packages/boogie/kodi-mpp-git/alarm-aarch64/src/xbmc/xbmc/games/addons/input/GameClientTopology.cpp -c -o CMakeFiles/gameinput.dir/GameClientTopology.cpp.o

```

PS: i mistakenly created the PR on 1.4, if needed i can create a new one for master, seems like github does not allow me to change the target branch of the PR
