### PR TITLE
Fix POSIX header paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,7 @@ AM_CONDITIONAL([WITH_ICECREAM_MAN], [test "x$build_man" != "xno"])
 
 # Some of these are needed by popt (or other libraries included in the future).
 
-AC_CHECK_HEADERS([sys/signal.h ifaddrs.h kinfo.h sys/param.h devstat.h])
+AC_CHECK_HEADERS([signal.h ifaddrs.h kinfo.h sys/param.h devstat.h])
 AC_CHECK_HEADERS([sys/socketvar.h sys/vfs.h])
 AC_CHECK_HEADERS([mach/host_info.h])
 AC_CHECK_HEADERS([arpa/nameser.h], [], [],

--- a/daemon/serve.cpp
+++ b/daemon/serve.cpp
@@ -36,9 +36,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#ifdef HAVE_SYS_SIGNAL_H
-#  include <sys/signal.h>
-#endif /* HAVE_SYS_SIGNAL_H */
+#ifdef HAVE_SIGNAL_H
+#  include <signal.h>
+#endif /* HAVE_SIGNAL_H */
 #include <sys/param.h>
 #include <unistd.h>
 

--- a/daemon/workit.cpp
+++ b/daemon/workit.cpp
@@ -39,7 +39,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/wait.h>
 #include <signal.h>
 #include <sys/resource.h>

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -32,7 +32,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <poll.h>
-#include <sys/signal.h>
+#include <signal.h>
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/services/util.h
+++ b/services/util.h
@@ -22,7 +22,7 @@
 #define ICECREAM_UTIL_H
 
 #include <string>
-#include <sys/poll.h>
+#include <poll.h>
 #include <vector>
 #include <unistd.h>
 


### PR DESCRIPTION
The sys/{fcntl,poll,signal}.h paths are historic and should not be used,
except perhaps in pre-POSIX.1-2001 systems.
