### PR TITLE
Fix for -Wp,MD

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -348,6 +348,14 @@ int analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<st
                 args.append(a, Arg_Local);
                 /* These two generate dependencies as a side effect.  They
                  * should work with the way we call cpp. */
+                if (str_startswith("-Wp,-MD", a) || str_startswith("-Wp,-MMD", a)) {
+                    /* When -Wp,-MD or -Wp,-MMD includes a filename */
+                    const char* comma = strchr(a + 7, ',');
+                    if (comma != nullptr) {
+                        seen_mf = true;
+                        /* we saw the filename so don't add additional -MF */
+                    }
+                }
             } else if (!strcmp(a, "-MG") || !strcmp(a, "-MP")) {
                 args.append(a, Arg_Local);
                 /* These just modify the behaviour of other -M* options and do


### PR DESCRIPTION
This fix ensures that icecc properly handles dependency arguments where the filename is embedded in the option itself, rather than trying to override it with its own dependency file specification.

When I build dpdk (from ceph), icecc emits following error.
We can see that this is caused by icecc correctly identifying `-Wp,-MD,./.telemetry_legacy.o.d.tmp` as a dependency-generating option but then incorrectly adding its own -MF option later:
```
root@kraken:/ceph/src/spdk/dpdk# /usr/local/libexec/icecc/bin/clang -Wp,-MD,./.telemetry_legacy.o.d.tmp  -m64 -pthread -I/ceph/src/spdk/dpdk/lib/librte_eal/linux/include  -march=corei7 -DRTE_MACHINE_CPUFLAG_SSE -DRTE_MACHINE_CPUFLAG_SSE2 -DRTE_MACHINE_CPUFLAG_SSE3 -DRTE_MACHINE_CPUFLAG_SSSE3 -DRTE_MACHINE_CPUFLAG_SSE4_1 -DRTE_MACHINE_CPUFLAG_SSE4_2 -I/ceph/build.u2204/src/dpdk/include -DRTE_USE_FUNCTION_VERSIONING -include /ceph/build.u2204/src/dpdk/include/rte_config.h -DALLOW_EXPERIMENTAL_API -DALLOW_INTERNAL_API -D_GNU_SOURCE -O3 -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wold-style-definition -Wpointer-arith -Wnested-externs -Wcast-qual -Wformat-nonliteral -Wformat-security -Wundef -Wwrite-strings -Wdeprecated -Wno-missing-field-initializers -Wno-address-of-packed-member -I/ceph/src/spdk/dpdk/lib/librte_telemetry -I/ceph/src/spdk/dpdk/lib/librte_metrics/ -I/ceph/src/spdk/dpdk/lib/librte_eal/include -I/ceph/src/spdk/dpdk/lib/librte_eal/x86/include -pthread   -fPIC -o telemetry_legacy.o -c /ceph/src/spdk/dpdk/lib/librte_telemetry/telemetry_legacy.c
sed: can't read ./.telemetry_legacy.o.d.tmp: No such file or directory
gmake[3]: *** [/ceph/src/spdk/dpdk/mk/internal/rte.compile-pre.mk:116: telemetry_legacy.o] Error 2
gmake[2]: *** [/ceph/src/spdk/dpdk/mk/rte.subdir.mk:37: librte_telemetry] Error 2
gmake[1]: *** [/ceph/src/spdk/dpdk/mk/rte.sdkbuild.mk:53: lib] Error 
```