### PR TITLE
Bugfixes

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -556,8 +556,12 @@ int main(int argc, char **argv)
         }
         catch (client_error& error) {
             if (remote_daemon.size()) {
-                log_error() << "got exception " << error.what()
-                            << " (" << remote_daemon.c_str() << ") " << endl;
+                if( error.errorCode == 2 ) {
+                    log_warning() << "got exception " << error.what() << " (" << remote_daemon.c_str() << ") " << endl;
+                }
+                else {
+                    log_error() << "got exception " << error.what() << " (" << remote_daemon.c_str() << ") " << endl;
+                }
             } else {
                 log_error() << "got exception " << error.what() << " (this should be an exception!)" <<
                             endl;

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -592,10 +592,10 @@ int main(int argc, char **argv)
 
         /* Inform the daemon that we like to start a job.  */
         if (local_daemon->send_msg(JobLocalBeginMsg(0, get_absfilename(job.outputFile()),fulljob))) {
-            /* Now wait until the daemon gives us the start signal.  40 minutes
-               should be enough for all normal compile or link jobs, but with expensive jobs
-               (which fulljobs may likely be, e.g. LTO linking) use an even larger timeout.  */
-            startme = local_daemon->get_msg(fulljob ? 120 * 60 : 40 * 60);
+            // Now wait until the daemon gives us the start signal. This can take a while on 
+            // big projects with many scheduled linker jobs waiting to run locally. So use a 
+            // large timeout of 120 minutes.
+            startme = local_daemon->get_msg(120 * 60);
         }
 
         /* If we can't talk to the daemon anymore we need to fall back

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -314,8 +314,8 @@ public:
         uint32_t min_niceness = std::numeric_limits<uint32_t>::max();
 
         for (auto it : *this) {
-            if (it.second->status == s && (!min_client_id || min_client_id > it.second->client_id)
-                && it.second->niceness < min_niceness ) {
+            if ( (it.second->status == s) 
+            && ((it.second->niceness < min_niceness) || ((it.second->niceness == min_niceness) && (it.second->client_id < min_client_id))) ) {
                 client = it.second;
                 min_client_id = client->client_id;
                 min_niceness = client->niceness;

--- a/scheduler/compileserver.cpp
+++ b/scheduler/compileserver.cpp
@@ -243,6 +243,11 @@ void CompileServer::setNodeName(const string &name)
     m_nodeName = name;
 }
 
+void CompileServer::setNextConnTime(time_t time)
+{
+    m_nextConnTime = time;
+}
+
 bool CompileServer::matches(const string& nm) const
 {
     return m_nodeName == nm || name == nm;

--- a/scheduler/compileserver.cpp
+++ b/scheduler/compileserver.cpp
@@ -47,7 +47,7 @@ CompileServer::CompileServer(const int fd, struct sockaddr *_addr, const socklen
     , m_hostPlatform()
     , m_load(1000)
     , m_maxJobs(0)
-    , m_noRemote(false)
+    , m_noRemote(true)
     , m_jobList()
     , m_state(CONNECTED)
     , m_type(UNKNOWN)
@@ -67,7 +67,7 @@ CompileServer::CompileServer(const int fd, struct sockaddr *_addr, const socklen
     , m_inConnAttempt(0)
     , m_nextConnTime(0)
     , m_lastConnStartTime(0)
-    , m_acceptingInConnection(true)
+    , m_acceptingInConnection(false)
 {
 }
 

--- a/scheduler/compileserver.h
+++ b/scheduler/compileserver.h
@@ -91,6 +91,8 @@ public:
     bool noRemote() const;
     void setNoRemote(const bool value);
 
+    void setNextConnTime(time_t time);
+
     const list<Job *>& jobList() const;
     void appendJob(Job *job);
     void removeJob(Job *job);

--- a/scheduler/scheduler.cpp
+++ b/scheduler/scheduler.cpp
@@ -1237,12 +1237,17 @@ static bool handle_login(CompileServer *cs, Msg *_m)
 
     handle_monitor_stats(cs);
 
-    /* remove any other clients with the same IP and name, they must be stale */
+    // remove any other clients with the same IP and name, they must be stale.
+    // In this case, postpone connection test for 5 minutes to prevent
+    // scheduling jobs to servers with unstable connections.
     for (list<CompileServer *>::iterator it = css.begin(); it != css.end();) {
         if (cs->eq_ip(*(*it)) && cs->nodeName() == (*it)->nodeName()) {
             CompileServer *old = *it;
             ++it;
             handle_end(old, nullptr);
+            if (!cs->noRemote()) {
+                cs->setNextConnTime(time(nullptr) + 5*60);
+            }
             continue;
         }
 

--- a/scheduler/scheduler.h
+++ b/scheduler/scheduler.h
@@ -27,13 +27,6 @@
 // Values 0 to 3.
 #define DEBUG_SCHEDULER 0
 
-// The weight the "fastest" scheduler places on using a
-// server with recent statistics over one that has not
-// been used for a while. Values 0 - 128, with higher
-// values meaning the "fastest" servers are used more
-// often.
-#define STATS_UPDATE_WEIGHT 120
-
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
Several bugfixes:

**Fix wrong logic in scheduling jobs fist-in-first-out**
Logic was not working to take oldest jobs first (FIFO) which could make linker jobs pending for a very long time, eventually leading to a timeout.

**Increase remote job timeout to 120 minutes in any case**
For very big projcets with many linker jobs, jobs can be pending for a long time. Especially in combination with the bug above. The lower 40 minute timeout on non-full jobs is not really a useful timeout anyway. Its a long time anyway if the job really ends up hanging in this state.

**Fix broken file locking**
The job timeout desribed above leads to local compiling without iccecc using file locking instead. If exec() is not called from the forked subprocess these locks will be closed and not working. Leading to unlimited number of local jobs running. This also happends if icecc is used without the iceccd daemon running.
 
**change default state of noRemote and acceptingInConnection**
To prevent connections to servers until their state is known.
    
**Revert logic for distributing some jobs to idle servers.** 
The replaced logic always evaluates to false.
    
**Degrade 'no server found behind given hostname' to warning.** 
This can happend when a server disconnects.

**postpone connection test for 5 minutes for lost reconnecting serves**
To prevent scheduling jobs on unstable servers
