### PR TITLE
ldconfig expects an /etc directory.

### DIFF
--- a/client/icecc-create-env.in
+++ b/client/icecc-create-env.in
@@ -580,6 +580,7 @@ for i in $target_files; do
 done
 
 if test -x /sbin/ldconfig -a "$is_linux" = 1; then
+   mkdir -p $tempdir/etc
    mkdir -p $tempdir/var/cache/ldconfig
    /sbin/ldconfig -r $tempdir
    for candidate in etc var/cache/ldconfig; do


### PR DESCRIPTION
When running in a rather custom container, I had:

/sbin/ldconfig: Can't create temporary cache file /tmp/iceccenvQymE4P/etc/ld.so.cache.WlqCmh: No such file or directory /usr/bin/md5sum: /tmp/iceccenvQymE4P/etc/ld.so.cache: No such file or directory creating 8e81fdd5dbd6be75f68b3577b696872f.tar.gz
tar: etc/ld.so.cache: Cannot stat: No such file or directory tar: Exiting with failure status due to previous errors Couldn't create archive

this one-liner fixes that.